### PR TITLE
Combopoints and vehicles

### DIFF
--- a/elements/cpoints.lua
+++ b/elements/cpoints.lua
@@ -8,7 +8,7 @@ local Update = function(self, event, unit)
 	if(unit == 'pet') then return end
 
 	local cp
-	if(UnitExists'vehicle') then
+	if(UnitHasVehicleUI'player') then
 		cp = GetComboPoints('vehicle', 'target')
 	else
 		cp = GetComboPoints('player', 'target')

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -180,7 +180,7 @@ local tagStrings = {
 
 	["cpoints"] = [[function(u)
 		local cp
-		if(UnitExists'vehicle') then
+		if(UnitHasVehicleUI'player') then
 			cp = GetComboPoints('vehicle', 'target')
 		else
 			cp = GetComboPoints('player', 'target')


### PR DESCRIPTION
I found this issue while questing in Deepholm, one fight there, specifically Resonating Blow, used the vehicle unit, but the player still had full control.
