### PR TITLE
Fixing the male worgen portrait problem. You can now use SetPortraitZoom 

### DIFF
--- a/elements/portraits.lua
+++ b/elements/portraits.lua
@@ -15,11 +15,10 @@ local Update = function(self, event, unit)
 			portrait:SetModel"Interface\\Buttons\\talktomequestionmark.mdx"
 		elseif(portrait.guid ~= guid or event == 'UNIT_MODEL_CHANGED') then
 			portrait:SetUnit(unit)
-			portrait:SetCamera(0)
-
+			portrait:SetPortraitZoom(1)
 			portrait.guid = guid
 		else
-			portrait:SetCamera(0)
+			portrait:SetPortraitZoom(1)
 		end
 	else
 		SetPortraitTexture(portrait, unit)


### PR DESCRIPTION
Fixing the male worgen portrait problem. You can now use SetPortraitZoom instead on SetCamera. That new and yet not documented WoW API function got introduces with the new SetDisplayID() functionality in Cataclysm. (Mainly for showing Quest NPC's that you do not have yet in your cache).
