### PR TITLE
Portrait fixes revised

### DIFF
--- a/elements/portraits.lua
+++ b/elements/portraits.lua
@@ -10,16 +10,19 @@ local Update = function(self, event, unit)
 	if(portrait:IsObjectType'Model') then
 		local guid = UnitGUID(unit)
 		if(not UnitExists(unit) or not UnitIsConnected(unit) or not UnitIsVisible(unit)) then
-			portrait:SetModelScale(4.25)
-			portrait:SetPosition(0, 0, -1.5)
-			portrait:SetModel"Interface\\Buttons\\talktomequestionmark.mdx"
+			portrait:ClearModel()
+			portrait:SetModel('interface\\buttons\\talktomequestionmark.m2')
+			portrait:SetCamDistanceScale(0.25)
+			portrait:SetPortraitZoom(0)
+			portrait:SetPosition(0,0,0.5)			
+			portrait.guid = nil
 		elseif(portrait.guid ~= guid or event == 'UNIT_MODEL_CHANGED') then
+			portrait:ClearModel()
 			portrait:SetUnit(unit)
-			portrait:SetCamera(0)
-
+			portrait:SetCamDistanceScale(1)
+			portrait:SetPortraitZoom(1)
+			portrait:SetPosition(0,0,0)
 			portrait.guid = guid
-		else
-			portrait:SetCamera(0)
 		end
 	else
 		SetPortraitTexture(portrait, unit)


### PR DESCRIPTION
I have to revise my previous pull request. I did some intense testing today and found bugs that had to be fixed. Adding "portrait.guid = nil" to the questionmark conditon prevents the questionmark from sticking. This can happen if you have the unit next to you, loose it by range and get it back later on.
I learned that reseting model values sometimes does not work correctly. You need to use  model:ClearModel() in first place to make the values apply correctly.
Oh...on a sidenote the else condition seems to be obsolete so I removed it. It works fine without.
