### PR TITLE
Easier fallback colors for power

### DIFF
--- a/elements/power.lua
+++ b/elements/power.lua
@@ -3,9 +3,7 @@ local oUF = ns.oUF
 
 oUF.colors.power = {}
 for power, color in next, PowerBarColor do
-	if(type(power) == 'string') then
-		oUF.colors.power[power] = {color.r, color.g, color.b}
-	end
+	oUF.colors.power[power] = {color.r, color.g, color.b}
 end
 
 local GetDisplayPower = function(power, unit)
@@ -42,12 +40,8 @@ local Update = function(self, event, unit)
 	elseif(power.colorDisconnected and not UnitIsConnected(unit)) then
 		t = self.colors.disconnected
 	elseif(power.colorPower) then
-		local ptype, ptoken, altR, altG, altB = UnitPowerType(unit)
-
-		t = self.colors.power[ptoken]
-		if(not t and altR) then
-			r, g, b = altR, altG, altB
-		end
+		local ptype, ptoken = UnitPowerType(unit)
+		t = self.colors.power[ptoken] or self.colors.power[ptype] or self.colors.power["MANA"]
 	elseif(power.colorClass and UnitIsPlayer(unit)) or
 		(power.colorClassNPC and not UnitIsPlayer(unit)) or
 		(power.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then


### PR DESCRIPTION
The PowerBarColors table contains numerically indexed entries as a fallback for when there is not an entry for the corresponding powerToken. Currently oUF's power element only copies the powerToken entries into oUF.colors.power and relies on the altR, altG and altB return values of UnitPowerType for a fallback and thus requires layout authors to include all POWER_TYPE_\* from FrameXML/ClobalStrings.lua if they want custom coloring for the power bar. It would be easier in my optinion if we could provide a fallback by powerType as it is done in FrameXML/UnitFrame.lua as so we don't have to look into FrameXML/ClobalStrings.lua every patch for new POWER_TYPE_\* entries.

This patch allows for such a fallback. I left the altR, altG, altB case in if ptype is nil as I don't know if it always returns something for alternative power types.
