### PR TITLE
Replacing :Show method of disabled Blizzard frames causing taint

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -49,6 +49,9 @@ function oUF:DisableBlizzard(unit)
 		PlayerFrame:RegisterEvent('UNIT_ENTERED_VEHICLE')
 		PlayerFrame:RegisterEvent('UNIT_EXITING_VEHICLE')
 		PlayerFrame:RegisterEvent('UNIT_EXITED_VEHICLE')
+		-- Disable vehicle transition animations while hidden
+		PlayerFrame:SetUserPlaced(true) -- User placed frames don't animate
+		PlayerFrame:SetDontSavePosition(true)
 	elseif(unit == 'pet') then
 		HandleFrame(PetFrame)
 	elseif(unit == 'target') then


### PR DESCRIPTION
When oUF replaces the :Show method of Blizzard frames to keep them hidden, it causes taint which breaks `FrameXML/AnimationSystem.lua`.  Here's an example `ADDON_ACTION_BLOCKED` stacktrace from entering a vehicle while in combat:

```
1x <event>ADDON_ACTION_BLOCKED:AddOn 'oUF' tried to call the protected function 'PetFrame:Show()'.
<in C code>: in function 'Show'
Interface\FrameXML\PetFrame.lua:49: in function 'PetFrame_Update':
Interface\FrameXML\PlayerFrame.lua:325: in function 'animPostFunc':
Interface\FrameXML\AnimationSystem.lua:22: in function <Interface\FrameXML\AnimationSystem.lua:10>:
Interface\FrameXML\AnimationSystem.lua:35: in function <Interface\FrameXML\AnimationSystem.lua:29>:
```

AnimationSystem slides the player and pet frames around to represent hopping into a vehicle (even when those frames are disabled by oUF), and then fails when attempting to show those frames, which triggers the `ADDON_ACTION_BLOCKED` event above.

I propose re-parenting disabled unit frames to a hidden parent instead of replacing their :Show method, so they remain hidden without tainting the default UI at all.  The default UI only references unit frame parents for frames like TargetOfTarget, but since they'll be disabled anyway, those GetParent calls will never happen.
