### PR TITLE
Fix Holy Power update.

### DIFF
--- a/elements/holypower.lua
+++ b/elements/holypower.lua
@@ -9,7 +9,8 @@
  Examples
 
    local HolyPower = {}
-   for index = 1, MAX_HOLY_POWER do
+   local maxHolyPower = UnitPowerMax('player', SPELL_POWER_HOLY_POWER)
+   for index = 1, maxHolyPower do
       local Texture = self:CreateTexture(nil, 'BACKGROUND')
    
       -- Position and size
@@ -36,7 +37,6 @@ local parent, ns = ...
 local oUF = ns.oUF
 
 local SPELL_POWER_HOLY_POWER = SPELL_POWER_HOLY_POWER
-local MAX_HOLY_POWER = MAX_HOLY_POWER
 
 local Update = function(self, event, unit, powerType)
 	if(self.unit ~= unit or (powerType and powerType ~= 'HOLY_POWER')) then return end
@@ -44,8 +44,9 @@ local Update = function(self, event, unit, powerType)
 	local hp = self.HolyPower
 	if(hp.PreUpdate) then hp:PreUpdate() end
 
+	local maxHolyPower = UnitPowerMax('player', SPELL_POWER_HOLY_POWER)
 	local num = UnitPower('player', SPELL_POWER_HOLY_POWER)
-	for i = 1, MAX_HOLY_POWER do
+	for i = 1, maxHolyPower do
 		if(i <= num) then
 			hp[i]:Show()
 		else


### PR DESCRIPTION
The constant MAX_HOLY_POWER has been removed. Holy Power in Pandaria can be up to five units. This tests the current maximum and uses that.
