### PR TITLE
altpowerbar: use api to set statusbar colour

### DIFF
--- a/elements/altpowerbar.lua
+++ b/elements/altpowerbar.lua
@@ -9,6 +9,11 @@
 
  AltPowerBar - A StatusBar to represent alternative power.
 
+ Options
+
+ .color             - Use `self.color = {255, 0, 0}` to have a red bar instead
+ 					  for instance.
+
  Examples
 
    -- Position and size
@@ -47,13 +52,24 @@ local UpdatePower = function(self, event, unit, powerType)
 	end
 
 	local barType, min = UnitAlternatePowerInfo(unit)
+
+
+	local texturePath, r, g, b 
+
+	if altpowerbar.color then
+		r, g, b = unpack(altpowerbar.color)
+	else
+		texturePath, r, g, b = UnitAlternatePowerTextureInfo(unit, 2)
+	end
+
 	local cur = UnitPower(unit, ALTERNATE_POWER_INDEX)
 	local max = UnitPowerMax(unit, ALTERNATE_POWER_INDEX)
-
+	
 	altpowerbar.barType = barType
 	altpowerbar:SetMinMaxValues(min, max)
 	altpowerbar:SetValue(cur)
-
+	altpowerbar:SetStatusBarColor(r, g, b)
+	
 	--[[ :PostUpdate(min, cur, max)
 
 	 Called after the element has been updated.


### PR DESCRIPTION
A lot of encounters are using alt power bars now and on some fights, the colour means something specific. i.e on The Stone Guard, which boss is actively charging up.

This change makes the alt power bar use the API to get its colour, unless `altpowerbar.color` is set.
