### PR TITLE
altpowerbar: allow layouts to position the tooltip

### DIFF
--- a/elements/altpowerbar.lua
+++ b/elements/altpowerbar.lua
@@ -151,7 +151,9 @@ local Enable = function(self, unit)
 		altpowerbar:Hide()
 
 		if(altpowerbar:IsMouseEnabled()) then
-			altpowerbar:SetScript('OnEnter', OnEnter)
+			if(not altpowerbar:HasScript('OnEnter')) then
+				altpowerbar:SetScript('OnEnter', OnEnter)
+			end
 			altpowerbar:SetScript('OnLeave', OnLeave)
 
 			if(not altpowerbar.UpdateTooltip) then


### PR DESCRIPTION
One could then use something like this

``` lua
    self.AltPowerBar.OnEnter = function(self)
        GameTooltip:SetOwner(self, "ANCHOR_TOPLEFT", 0, 5)
        self:UpdateTooltip()
    end

    self.AltPowerBar:EnableMouse()
    self.AltPowerBar:SetScript("OnEnter", self.AltPowerBar.OnEnter)
```
