### PR TITLE
Fix for userdata value error in aura.lua on ForceUpdate

### DIFF
--- a/elements/aura.lua
+++ b/elements/aura.lua
@@ -51,7 +51,7 @@
    local Buffs = CreateFrame("Frame", nil, self)
    Buffs:SetPoint("RIGHT", self, "LEFT")
    Buffs:SetSize(16 * 2, 16 * 16)
-   
+
    -- Register with oUF
    self.Buffs = Buffs
 
@@ -434,17 +434,17 @@ local Update = function(self, event, unit)
 	if(event == 'ForceUpdate' or not event) then
 		local buffs = self.Buffs
 		if(buffs) then
-			(buffs.SetPosition or SetPosition) (buffs, 0, buffs.createdIcons)
+			(buffs.SetPosition or SetPosition) (buffs, 1, buffs.createdIcons)
 		end
 
 		local debuffs = self.Debuffs
 		if(debuffs) then
-			(debuffs.SetPosition or SetPosition) (debuffs, 0, debuffs.createdIcons)
+			(debuffs.SetPosition or SetPosition) (debuffs, 1, debuffs.createdIcons)
 		end
 
 		local auras = self.Auras
 		if(auras) then
-			(auras.SetPosition or SetPosition) (auras, 0, auras.createdIcons)
+			(auras.SetPosition or SetPosition) (auras, 1, auras.createdIcons)
 		end
 	end
 end

--- a/elements/totems.lua
+++ b/elements/totems.lua
@@ -35,19 +35,19 @@
       local Totem = CreateFrame('Button', nil, self)
       Totem:SetSize(40, 40)
       Totem:SetPoint('TOPLEFT', self, 'BOTTOMLEFT', index * Totem:GetWidth(), 0)
-      
+
       local Icon = Totem:CreateTexture(nil, "OVERLAY")
       Icon:SetAllPoints()
-      
+
       local Cooldown = CreateFrame("Cooldown", nil, Totem)
       Cooldown:SetAllPoints()
-      
+
       Totem.Icon = Icon
       Totem.Cooldown = Cooldown
-      
+
       Totems[index] = Totem
    end
-   
+
    -- Register with oUF
    self.Totems = Totems
 


### PR DESCRIPTION
Calling ForceUpdate on aura elements was calling SetPosition with a "from" value of 0. Since the first icon sits at index 1, and index 0 on any frame object contains userdata, this triggers an error about trying to call frame methods on a userdata value, and breaks the aura element.
