### PR TITLE
Use RegisterUnitEvent to replace our home-brew event dispatcher.

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -6,104 +6,39 @@ local argcheck = Private.argcheck
 local error = Private.error
 local frame_metatable = Private.frame_metatable
 
--- Events
-local RegisterEvent, UnregisterEvent, IsEventRegistered
+-- Original event methods
+local RegisterEvent = frame_metatable.__index.RegisterEvent
+local RegisterUnitEvent = frame_metatable.__index.RegisterUnitEvent
+local UnregisterEvent = frame_metatable.__index.UnregisterEvent
+local IsEventRegistered = frame_metatable.__index.IsEventRegistered
 
-do
-	local eventFrame = CreateFrame("Frame")
-	local registry = {}
-	local framesForUnit = {}
+local unitEvents = {}
 
-	local RegisterFrameForUnit = function(frame, unit)
-		if not unit then return end
-		if framesForUnit[unit] then
-			framesForUnit[unit][frame] = true
-		else
-			framesForUnit[unit] = { [frame] = true }
-		end
+Private.UpdateUnits = function(frame, unit, realUnit)
+	if unit == realUnit then
+		realUnit = nil
 	end
-
-	local UnregisterFrameForUnit = function(frame, unit)
-		if not unit then return end
-		local frames = framesForUnit[unit]
-		if frames and frames[frame] then
-			frames[frame] = nil
-			if not next(frames) then
-				framesForUnit[unit] = nil
+	if frame.unit ~= unit or frame.realUnit ~= realUnit then
+		for event in next, unitEvents do
+			-- IsEventRegistered returns the units in case of an event
+			-- registered with RegisterUnitEvent
+			local registered, unit1, unit2 = IsEventRegistered(frame, event)
+			if registered and (unit1 ~= unit or unit2 ~= realUnit) then
+				-- RegisterUnitEvent erases previously registered units so
+				-- do not bother to unregister it
+				RegisterUnitEvent(frame, event, unit, realUnit)
 			end
 		end
+		frame.unit = unit
+		frame.realUnit = realUnit
+		frame.id = unit:match'^.-(%d+)'
+		return true
 	end
+end
 
-	Private.UpdateUnits = function(frame, unit, realUnit)
-		if unit == realUnit then
-			realUnit = nil
-		end
-		if frame.unit ~= unit or frame.realUnit ~= realUnit then
-			if not frame:GetScript('OnUpdate') then
-				UnregisterFrameForUnit(frame, frame.unit)
-				UnregisterFrameForUnit(frame, frame.realUnit)
-				RegisterFrameForUnit(frame, unit)
-				RegisterFrameForUnit(frame, realUnit)
-			end
-			frame.unit = unit
-			frame.realUnit = realUnit
-			frame.id = unit:match'^.-(%d+)'
-			return true
-		end
-	end
-
-	-- Holds true for every event, where the first (unit) argument should be ignored.
-	local sharedUnitEvents = {
-		UNIT_ENTERED_VEHICLE = true,
-		UNIT_EXITED_VEHICLE = true,
-		UNIT_PET = true,
-	}
-
-	eventFrame:SetScript('OnEvent', function(_, event, arg1, ...)
-		local listeners = registry[event]
-		if arg1 and not sharedUnitEvents[event] then
-			local frames = framesForUnit[arg1]
-			if frames then
-				for frame in next, frames do
-					if listeners[frame] and frame:IsVisible() then
-						frame[event](frame, event, arg1, ...)
-					end
-				end
-			end
-		else
-			for frame in next, listeners do
-				if frame:IsVisible() then
-					frame[event](frame, event, arg1, ...)
-				end
-			end
-		end
-	end)
-
-	function RegisterEvent(self, event, unitless)
-		if(unitless) then
-			sharedUnitEvents[event] = true
-		end
-
-		if not registry[event] then
-			registry[event] = { [self] = true }
-			eventFrame:RegisterEvent(event)
-		else
-			registry[event][self] = true
-		end
-	end
-
-	function UnregisterEvent(self, event)
-		if registry[event] then
-			registry[event][self] = nil
-			if not next(registry[event]) then
-				registry[event] = nil
-				eventFrame:UnregisterEvent(event)
-			end
-		end
-	end
-
-	function IsEventRegistered(self, event)
-		return registry[event] and registry[event][self]
+local OnEvent = function(self, event, ...)
+	if self:IsVisible() then
+		return self[event](self, event, ...)
 	end
 end
 
@@ -123,6 +58,11 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 
 	if(type(func) == 'string' and type(self[func]) == 'function') then
 		func = self[func]
+	end
+
+	-- TODO: should warn the user.
+	if not unitless and not (unitEvents[event] or event:match'^UNIT_') then
+		unitless = true
 	end
 
 	local curev = self[event]
@@ -146,7 +86,16 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 			return error("Style [%s] attempted to register event [%s] on unit [%s] with a handler that doesn't exist.", self.style, event, self.unit or 'unknown')
 		end
 
-		RegisterEvent(self, event, unitless)
+		if not self:GetScript('OnEvent') then
+			self:SetScript('OnEvent', OnEvent)
+		end
+
+		if unitless then
+			RegisterEvent(self, event)
+		else
+			unitEvents[event] = true
+			RegisterUnitEvent(self, event, self.unit, self.realUnit)
+		end
 	end
 end
 
@@ -164,6 +113,7 @@ function frame_metatable.__index:UnregisterEvent(event, func)
 					local _, handler = next(curev)
 					self[event] = handler
 				elseif(n == 0) then
+					-- This should not happen
 					UnregisterEvent(self, event)
 				end
 
@@ -174,8 +124,4 @@ function frame_metatable.__index:UnregisterEvent(event, func)
 		self[event] = nil
 		UnregisterEvent(self, event)
 	end
-end
-
-function frame_metatable.__index:IsEventRegistered(event)
-	return IsEventRegistered(self, event)
 end


### PR DESCRIPTION
Hello,

This PR gets rid of the central event dispatcher and the burden of maintaining unit-to-frames lisst by using the [frame:RegisterUnitEvent() API](http://wowpedia.org/API_Frame_RegisterUnitEvent) introduced in 5.0.4.

The code is smaller, I think it introduces less overhead by letting the dispatching happen on the C-side and it is working flawlessly since I wrote it one year ago.

Regards,
Adirelle.
