### PR TITLE
Altpowerbar tweaks

### DIFF
--- a/elements/altpowerbar.lua
+++ b/elements/altpowerbar.lua
@@ -118,8 +118,19 @@ local UpdatePower = function(self, event, unit, powerType)
 	end
 end
 
+
+--[[ Hooks
+
+ Override(self) - Used to completely override the internal update function.
+                  Removing the table key entry will make the element fall-back
+                  to its internal function again.
+]]
+local Path = function(self, ...)
+	return (self.AltPowerBar.Override or UpdatePower)(self, ...)
+end
+
 local ForceUpdate = function(element)
-	return UpdatePower(element.__owner, 'ForceUpdate', element.__owner.unit, 'ALTERNATE')
+	return Path(element.__owner, 'ForceUpdate', element.__owner.unit, 'ALTERNATE')
 end
 
 local Toggler = function(self, event, unit)
@@ -128,14 +139,14 @@ local Toggler = function(self, event, unit)
 
 	local barType, minPower, _, _, _, hideFromOthers = UnitAlternatePowerInfo(unit)
 	if(barType and (altpowerbar.showOthersAnyway or not hideFromOthers or unit == 'player' or self.realUnit == 'player')) then
-		self:RegisterEvent('UNIT_POWER', UpdatePower)
-		self:RegisterEvent('UNIT_MAXPOWER', UpdatePower)
+		self:RegisterEvent('UNIT_POWER', Path)
+		self:RegisterEvent('UNIT_MAXPOWER', Path)
 
 		ForceUpdate(altpowerbar)
 		altpowerbar:Show()
 	else
-		self:UnregisterEvent('UNIT_POWER', UpdatePower)
-		self:UnregisterEvent('UNIT_MAXPOWER', UpdatePower)
+		self:UnregisterEvent('UNIT_POWER', Path)
+		self:UnregisterEvent('UNIT_MAXPOWER', Path)
 
 		altpowerbar:Hide()
 	end


### PR DESCRIPTION
Tweaks:
- limits the value passed to :SetValue to the defined range.
- adds a .showOthersAnyway option to forcefully show powers flagged with hideFromOthers by the API.
- allows .Update override .
