### PR TITLE
Provides a color gradient based on hue/chroma/luma (HCY').

### DIFF
--- a/colors.lua
+++ b/colors.lua
@@ -144,12 +144,17 @@ local HCYColorGradient = function(...)
 
 end
 
+local ColorGradient = function(...)
+	return (oUF.useHCYColorGradient and HCYColorGradient or RGBColorGradient)(...)
+end
+
 Private.colors = colors
 
 oUF.colors = colors
-oUF.ColorGradient = RGBColorGradient
+oUF.ColorGradient = ColorGradient
 oUF.RGBColorGradient = RGBColorGradient
 oUF.HCYColorGradient = HCYColorGradient
+oUF.useHCYColorGradient = false
 
 frame_metatable.__index.colors = colors
-frame_metatable.__index.ColorGradient = RGBColorGradient
+frame_metatable.__index.ColorGradient = ColorGradient


### PR DESCRIPTION
Provides as oUF.HueBasedColorGradient. It can be used to override widgets' .ColorGradient.
