### PR TITLE
power: optimize a bit

### DIFF
--- a/elements/power.lua
+++ b/elements/power.lua
@@ -18,6 +18,10 @@
 
  Options
 
+ .displayAltPower   - Use this to let the widget display alternate power if the
+                      unit has one. If no alternate power the display will fall
+                      back to primary power.
+
  The following options are listed by priority. The first check that returns
  true decides the color of the bar.
 
@@ -112,10 +116,8 @@ oUF.colors.power[9] = oUF.colors.power["HOLY_POWER"]
 
 local GetDisplayPower = function(power, unit)
 	local _, _, _, _, _, _, showOnRaid = UnitAlternatePowerInfo(unit)
-	if(power.displayAltPower and showOnRaid) then
+	if(showOnRaid) then
 		return ALTERNATE_POWER_INDEX
-	else
-		return (UnitPowerType(unit))
 	end
 end
 
@@ -125,7 +127,7 @@ local Update = function(self, event, unit)
 
 	if(power.PreUpdate) then power:PreUpdate(unit) end
 
-	local displayType = GetDisplayPower(power, unit)
+	local displayType = power.displayAltPower and GetDisplayPower(power, unit)
 	local min, max = UnitPower(unit, displayType), UnitPowerMax(unit, displayType)
 	local disconnected = not UnitIsConnected(unit)
 	power:SetMinMaxValues(0, max)


### PR DESCRIPTION
This would spare a local and a global function call if the layout does not use power.displayAltPower. Otherwise the call of `UnitPowerType` is useless as `UnitPower(unit, nil)` and `UnitPowerMax(unit, nil)` will both return values for primary power.
