### PR TITLE
ClassIcons: Optimization and clean-up.

### DIFF
--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -123,6 +123,8 @@ local Update = function(self, event, unit, powerType)
 
 			element.__max = max
 		end
+	else
+		cur, max = 0, 0
 	end
 
 	if(element.PostUpdate) then


### PR DESCRIPTION
Fixes enable/disable bug, when player respecs. For example, if we login as a shadow priest, produce few orbs, then respec to holy, then respec back to shadow, we won't have our shard bar back.

Also fixed an issue when paladins had holypower and priests had shadow orbs starting level 1 instead of level 9 and 21 resp.

Got rid of specialization checks, starting now we only check if char has required spell. Warlocks - Soulburn, Paladins - Word of Glory, Priest - Shadow Orbs, Monks - none, always enabled,

Added a call of Path function on disable inside of Visibility function, just in case some needs to perform something via PostUpdate function right after we hid classicons.

Few minor tweaks.
