### PR TITLE
EclipseBar: Don't call PostUnitAura if the eclipse state didn't change

### DIFF
--- a/elements/eclipsebar.lua
+++ b/elements/eclipsebar.lua
@@ -140,6 +140,7 @@ local UNIT_AURA = function(self, event, unit)
 	until not spellID
 
 	local eb = self.EclipseBar
+	if(eb.hasSolarEclipse == hasSolarEclipse and eb.hasLunarEclipse == hasLunarEclipse) then return end
 	eb.hasSolarEclipse = hasSolarEclipse
 	eb.hasLunarEclipse = hasLunarEclipse
 


### PR DESCRIPTION
Also, do you have any particular objection to getting the eclipse buff names via GetSpellInfo and then just checking the two buffs by name in the UNIT_AURA handler instead of scanning over all the player's buffs? Scanning makes sense if you're looking for (de)buffs whose names aren't unique, but as far as I know (or have been able to determine via Wowhead) the eclipse buffs don't fall into that category. I've made this change in my local copy and haven't noticed any issues, but I didn't commit yet.
