### PR TITLE
Fixed aura cooldown animation.

### DIFF
--- a/elements/aura.lua
+++ b/elements/aura.lua
@@ -86,7 +86,7 @@ local createAuraIcon = function(icons, index)
 	local button = CreateFrame("Button", nil, icons)
 	button:RegisterForClicks'RightButtonUp'
 
-	local cd = CreateFrame("Cooldown", nil, button)
+	local cd = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
 	cd:SetAllPoints(button)
 
 	local icon = button:CreateTexture(nil, "BORDER")


### PR DESCRIPTION
Hi! Maybe that's just a problem of a current beta build, but aura cd animation stopped working O_o
Can be fixed by inheriting `CooldownFrameTemplate`, while creating cd frame, so here's a tiny patch, just in case it goes live.
