### PR TITLE
classicons: Keep the overrides consistent with the rest of the elements

### DIFF
--- a/elements/classicons.lua
+++ b/elements/classicons.lua
@@ -33,20 +33,17 @@
 
  Hooks
 
- Override(self)         - Used to completely override the internal update function.
-                          Removing the table key entry will make the element
-                          fall-back to its internal function again.
+ OverrideVisibility(self) - Used to completely override the internal visibility function.
+                            Removing the table key entry will make the element fall-back
+                            to its internal function again.
+ Override(self)           - Used to completely override the internal update function.
+                            Removing the table key entry will make the element fall-back
+                            to its internal function again.
+ UpdateTexture(element)   - Used to completely override the internal function for
+                            updating the power icon textures. Removing the table key
+                            entry will make the element fall-back to its internal
+                            function again.
 
- Visibility(self)       - Used to completely override the internal visibility function.
-                          Removing the table key entry will make the element
-                          fall-back to its internal function again.
-
- UpdateTexture(element) - Used to completely override the internal function for
-                          updating the power icon textures. Removing the table key
-                          entry will make the element fall-back to its internal
-                          function again.
-
- Callbacks
 ]]
 
 local parent, ns = ...
@@ -146,8 +143,7 @@ local Update = function(self, event, unit, powerType)
 	end
 end
 
-local Visibility
-Visibility = function(self, event, unit)
+local Visibility = function(self, event, unit)
 	local element = self.ClassIcons
 	local shouldEnable
 
@@ -175,7 +171,7 @@ local Path = function(self, ...)
 end
 
 local VisibilityPath = function(self, ...)
-	return (self.ClassIcons.Visibility or Visibility) (self, ...)
+	return (self.ClassIcons.OverrideVisibility or Visibility) (self, ...)
 end
 
 local ForceUpdate = function(element)


### PR DESCRIPTION
`OverrideVisibility` is already used in [elements\stagger.lua](https://github.com/haste/oUF/blob/c26bf17d179a75cb5722c26a3f833c7a29782dd2/elements/stagger.lua#L130), lets keep the elements consistent with each other.
