### PR TITLE
Since WoW 6.0 GetComboPoints() may return 0 instead of the correct combo point value

### DIFF
--- a/elements/cpoints.lua
+++ b/elements/cpoints.lua
@@ -36,11 +36,12 @@
 local parent, ns = ...
 local oUF = ns.oUF
 
-local GetComboPoints = GetComboPoints
 local MAX_COMBO_POINTS = MAX_COMBO_POINTS
 
-local Update = function(self, event, unit)
+local Update = function(self, event, unit,powerType)
 	if(unit == 'pet') then return end
+	if unit and (unit ~= 'player' and unit ~= 'vehicle') then return end
+	if powerType and powerType ~= 'COMBO_POINTS' then return end
 
 	local cpoints = self.CPoints
 	if(cpoints.PreUpdate) then
@@ -48,10 +49,10 @@ local Update = function(self, event, unit)
 	end
 
 	local cp
-	if(UnitHasVehicleUI'player') then
-		cp = GetComboPoints('vehicle', 'target')
+	if(UnitHasVehicleUI'player') and UnitPower('vehicle',4) >= 1 then
+		cp = UnitPower('vehicle',4)
 	else
-		cp = GetComboPoints('player', 'target')
+		cp = UnitPower('player',4)
 	end
 
 	for i=1, MAX_COMBO_POINTS do
@@ -72,7 +73,7 @@ local Path = function(self, ...)
 end
 
 local ForceUpdate = function(element)
-	return Path(element.__owner, 'ForceUpdate', element.__owner.unit)
+	return Path(element.__owner, 'ForceUpdate', element.__owner.unit, nil)
 end
 
 local Enable = function(self)
@@ -82,6 +83,7 @@ local Enable = function(self)
 		cpoints.ForceUpdate = ForceUpdate
 
 		self:RegisterEvent('UNIT_COMBO_POINTS', Path, true)
+		self:RegisterEvent('UNIT_POWER_FREQUENT', Path)
 		self:RegisterEvent('PLAYER_TARGET_CHANGED', Path, true)
 
 		for index = 1, MAX_COMBO_POINTS do
@@ -103,6 +105,7 @@ local Disable = function(self)
 			cpoints[index]:Hide()
 		end
 		self:UnregisterEvent('UNIT_COMBO_POINTS', Path)
+		self:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
 		self:UnregisterEvent('PLAYER_TARGET_CHANGED', Path)
 	end
 end


### PR DESCRIPTION
...0 from time to time

Changed the element to work with UnitPower(unit,4) which was introduced with patch 6.0.
The POWER_TYPE_INDEX of 4 references COMBO_POINTS since 6.0.
