### PR TITLE
Dont have oUF aura specific logic inside CreateIcon

### DIFF
--- a/elements/aura.lua
+++ b/elements/aura.lua
@@ -81,8 +81,6 @@ local OnLeave = function()
 end
 
 local createAuraIcon = function(icons, index)
-	icons.createdIcons = icons.createdIcons + 1
-
 	local button = CreateFrame("Button", nil, icons)
 	button:RegisterForClicks'RightButtonUp'
 
@@ -113,7 +111,6 @@ local createAuraIcon = function(icons, index)
 	button:SetScript("OnEnter", OnEnter)
 	button:SetScript("OnLeave", OnLeave)
 
-	table.insert(icons, button)
 
 	button.icon = icon
 	button.count = count
@@ -157,6 +154,9 @@ local updateIcon = function(unit, icons, index, offset, filter, isDebuff, visibl
 			 A button used to represent aura icons.
 			]]
 			icon = (icons.CreateIcon or createAuraIcon) (icons, n)
+			table.insert(icons, icon)
+			icons.createdIcons = icons.createdIcons + 1
+
 		end
 
 		local isPlayer


### PR DESCRIPTION
If a user overrides CreateIcon then they must also implement
oUF specific logic to make the rest of the aura code work.
Namely, inserting the new icon into icons and incrementing
createdIcons which are used by oUF's internal aura code.

These two operations can be pulled out of oUF's implementation
of createAuraIcon and allow overrides to not need to worry about
internal oUF behaviour.
