### PR TITLE
Feature: Arena Preparation

### DIFF
--- a/elements/health.lua
+++ b/elements/health.lua
@@ -89,12 +89,19 @@ local oUF = ns.oUF
 oUF.colors.health = {49/255, 207/255, 37/255}
 
 local Update = function(self, event, unit)
-	if(self.unit ~= unit) then return end
+	local arenaPrep = event == 'ArenaPreparation'
+	if(self.unit ~= unit and not arenaPrep) then return end
 	local health = self.Health
 
 	if(health.PreUpdate) then health:PreUpdate(unit) end
 
-	local min, max = UnitHealth(unit), UnitHealthMax(unit)
+	local min, max
+	if(arenaPrep) then
+		min, max = 1, 1
+	else
+		min, max = UnitHealth(unit), UnitHealthMax(unit)
+	end
+
 	local disconnected = not UnitIsConnected(unit)
 	health:SetMinMaxValues(0, max)
 

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -114,7 +114,10 @@ local Update = function(self, event, unit)
 	health.disconnected = disconnected
 
 	local r, g, b, t
-	if(health.colorTapping and not UnitPlayerControlled(unit) and
+	if(health.colorClass and arenaPrep) then
+		local _, _, _, _, _, _, class = GetSpecializationInfoByID(GetArenaOpponentSpec(self.id))
+		t = self.colors.class[class]
+	elseif(health.colorTapping and not UnitPlayerControlled(unit) and
 		UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit) and not
 		UnitIsTappedByAllThreatList(unit)) then
 		t = self.colors.tapped

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -154,7 +154,10 @@ local Update = function(self, event, unit)
 	power.disconnected = disconnected
 
 	local r, g, b, t
-	if(power.colorTapping and not UnitPlayerControlled(unit) and
+	if(power.colorClass and arenaPrep) then
+		local _, _, _, _, _, _, class = GetSpecializationInfoByID(GetArenaOpponentSpec(self.id))
+		t = self.colors.class[class]
+	elseif(power.colorTapping and not UnitPlayerControlled(unit) and
 		UnitIsTapped(unit) and not UnitIsTappedByPlayer(unit) and not
 		UnitIsTappedByAllThreatList(unit)) then
 		t = self.colors.tapped

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -124,7 +124,8 @@ local GetDisplayPower = function(unit)
 end
 
 local Update = function(self, event, unit)
-	if(self.unit ~= unit) then return end
+	local arenaPrep = event == 'ArenaPreparation'
+	if(self.unit ~= unit and not arenaPrep) then return end
 	local power = self.Power
 
 	if(power.PreUpdate) then power:PreUpdate(unit) end
@@ -133,7 +134,14 @@ local Update = function(self, event, unit)
 	if power.displayAltPower then
 		displayType, min = GetDisplayPower(unit)
 	end
-	local cur, max = UnitPower(unit, displayType), UnitPowerMax(unit, displayType)
+
+	local cur, max
+	if(arenaPrep) then
+		cur, max = 1, 1
+	else
+		cur, max = UnitPower(unit, displayType), UnitPowerMax(unit, displayType)
+	end
+
 	local disconnected = not UnitIsConnected(unit)
 	power:SetMinMaxValues(min or 0, max)
 

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -329,6 +329,17 @@ local tagStrings = {
 			return 'Affix'
 		end
 	end]],
+
+	['arenaspec'] = [[function(u)
+		local id = u:match'arena(%d)$'
+		if(id) then
+			local specID = GetArenaOpponentSpec(tonumber(id))
+			if(specID and specID > 0) then
+				local _, specName = GetSpecializationInfoByID(specID)
+				return specName
+			end
+		end
+	end]],
 }
 
 local tags = setmetatable(
@@ -412,6 +423,7 @@ local tagEvents = {
 	['holypower']           = 'UNIT_POWER SPELLS_CHANGED',
 	['chi']                 = 'UNIT_POWER',
 	['shadoworbs']          = 'UNIT_POWER SPELLS_CHANGED',
+	['arenaspec']           = 'ARENA_PREP_OPPONENT_SPECIALIZATIONS'
 }
 
 local unitlessEvents = {
@@ -423,7 +435,9 @@ local unitlessEvents = {
 
 	GROUP_ROSTER_UPDATE = true,
 
-	UNIT_COMBO_POINTS = true
+	UNIT_COMBO_POINTS = true,
+
+	ARENA_PREP_OPPONENT_SPECIALIZATIONS = true,
 }
 
 local events = {}

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -122,6 +122,15 @@ local tagStrings = {
 		local _, x = UnitClass(u)
 		if(x) then
 			return Hex(_COLORS.class[x])
+		else
+			local id = u:match'arena(%d)$'
+			if(id) then
+				local specID = GetArenaOpponentSpec(tonumber(id))
+				if(specID and specID > 0) then
+					_, _, _, _, _, _, x = GetSpecializationInfoByID(specID)
+					return Hex(_COLORS.class[x])
+				end
+			end
 		end
 	end]],
 

--- a/ouf.lua
+++ b/ouf.lua
@@ -76,6 +76,7 @@ local function updateArenaPreparation(self, event)
 			end
 
 			self:Show()
+			self:ForceUpdateAllElements('ArenaPreparation')
 		end
 	end
 end
@@ -165,20 +166,24 @@ for k, v in pairs{
 		self:Hide()
 	end,
 
-	UpdateAllElements = function(self, event)
-		local unit = self.unit
-		if(not UnitExists(unit)) then return end
-
+	ForceUpdateAllElements = function(self, event)
 		if(self.PreUpdate) then
 			self:PreUpdate(event)
 		end
 
+		local unit = self.unit
 		for _, func in next, self.__elements do
 			func(self, event, unit)
 		end
 
 		if(self.PostUpdate) then
 			self:PostUpdate(event)
+		end
+	end,
+
+	UpdateAllElements = function(self, event)
+		if(UnitExists(self.unit)) then
+			self:ForceUpdateAllElements(event)
 		end
 	end,
 } do

--- a/ouf.lua
+++ b/ouf.lua
@@ -62,7 +62,7 @@ local updateActiveUnit = function(self, event, unit)
 end
 
 local function updateArenaPreparation(self, event)
-	if(event == 'ARENA_OPPONENT_UPDATE' and not UnitWatchRegistered(self)) then
+	if(event == 'ARENA_OPPONENT_UPDATE' and not self:IsEnabled()) then
 		self:Enable()
 		self:UnregisterEvent(event, updateArenaPreparation)
 	elseif(event == 'PLAYER_ENTERING_WORLD' and not UnitExists(self.unit)) then
@@ -70,7 +70,7 @@ local function updateArenaPreparation(self, event)
 	elseif(event == 'ARENA_PREP_OPPONENT_SPECIALIZATIONS') then
 		local specID = GetArenaOpponentSpec(self.id)
 		if(specID) then
-			if(UnitWatchRegistered(self)) then
+			if(self:IsEnabled()) then
 				self:Disable()
 				self:RegisterEvent('ARENA_OPPONENT_UPDATE', updateArenaPreparation)
 			end
@@ -160,6 +160,7 @@ for k, v in pairs{
 		return active and active[name]
 	end,
 
+	IsEnabled = UnitWatchRegistered,
 	Enable = RegisterUnitWatch,
 	Disable = function(self)
 		UnregisterUnitWatch(self)


### PR DESCRIPTION
This adds support for arena preparation frames, a solution to #177.

By taking over the `arena#` frames' state driver until the unitIDs become available, this PR achieves the following:
- Displaying the frames with bogus health/power information
- Class color support on health/power elements
- Class color support in `[raidcolor]` tag
- New tag `[arenaspec]` which also work on the normal `arena#` frames

That should cover most of the available features with the arena prep system, and it requires no additional setup for the layout (plug-n-play).

Please test!
