### PR TITLE
power: changed and updated source for colors

### DIFF
--- a/elements/power.lua
+++ b/elements/power.lua
@@ -98,8 +98,6 @@
 local parent, ns = ...
 local oUF = ns.oUF
 
-local isBetaClient = select(4, GetBuildInfo()) >= 70000
-
 oUF.colors.power = {}
 for power, color in next, PowerBarColor do
 	if (type(power) == "string") then
@@ -115,36 +113,21 @@ for power, color in next, PowerBarColor do
 	end
 end
 
-if(isBetaClient) then
-	-- COMBO_POINTS don't have a color pre-Legion so we need to supply that color
-	oUF.colors.power.COMBO_POINTS = {1, 0.96, 0.41}
-end
-
--- sourced from FrameXML/Constants.lua
+-- sourced from FrameXML/UnitFrame.lua
 oUF.colors.power[0] = oUF.colors.power.MANA
 oUF.colors.power[1] = oUF.colors.power.RAGE
 oUF.colors.power[2] = oUF.colors.power.FOCUS
 oUF.colors.power[3] = oUF.colors.power.ENERGY
-oUF.colors.power[4] = oUF.colors.power.COMBO_POINTS
+oUF.colors.power[4] = oUF.colors.power.CHI
 oUF.colors.power[5] = oUF.colors.power.RUNES
 oUF.colors.power[6] = oUF.colors.power.RUNIC_POWER
 oUF.colors.power[7] = oUF.colors.power.SOUL_SHARDS
+oUF.colors.power[8] = oUF.colors.power.LUNAR_POWER
 oUF.colors.power[9] = oUF.colors.power.HOLY_POWER
-oUF.colors.power[12] = oUF.colors.power.CHI
-
-if(isBetaClient) then
-	oUF.colors.power[8] = oUF.colors.power.LUNAR_POWER
-	oUF.colors.power[11] = oUF.colors.power.MAELSTROM
-	oUF.colors.power[13] = oUF.colors.power.INSANITY
-	oUF.colors.power[16] = oUF.colors.power.ARCANE_CHARGES
-	oUF.colors.power[17] = oUF.colors.power.FURY
-	oUF.colors.power[18] = oUF.colors.power.PAIN
-else
-	oUF.colors.power[8] = oUF.colors.power.ECLIPSE
-	oUF.colors.power[13] = oUF.colors.power.SHADOW_ORBS
-	oUF.colors.power[14] = oUF.colors.power.BURNING_EMBERS
-	oUF.colors.power[15] = oUF.colors.power.DEMONIC_FURY
-end
+oUF.colors.power[11] = oUF.colors.power.MAELSTROM
+oUF.colors.power[13] = oUF.colors.power.INSANITY
+oUF.colors.power[17] = oUF.colors.power.FURY
+oUF.colors.power[18] = oUF.colors.power.PAIN
 
 local GetDisplayPower = function(unit)
 	local _, min, _, _, _, _, showOnRaid = UnitAlternatePowerInfo(unit)


### PR DESCRIPTION
As a source for oUF.colors.power should be used FrameXML/UnitFrame.lua not the FrameXML/Constants.lua. Why? Because [here](https://github.com/haste/oUF/blob/master/elements/power.lua#L104) is used a PowerBarColor function, which gets data from FrameXML/UnitFrame.lua

proof:
`/run for k, v in pairs( PowerBarColor[4]  ) do print(k, v) end`
After runinig this macro in WoW we get: 
![gskaep2](https://cloud.githubusercontent.com/assets/3687309/17254595/af35b96e-55b5-11e6-8bab-881f8bebed13.png)
This is color of Chi not the Combo Points, so old source is wrong.
