### PR TITLE
power: allow using atlases

### DIFF
--- a/elements/power.lua
+++ b/elements/power.lua
@@ -71,12 +71,12 @@
    Power:SetPoint('BOTTOM')
    Power:SetPoint('LEFT')
    Power:SetPoint('RIGHT')
-   
+
    -- Add a background
    local Background = Power:CreateTexture(nil, 'BACKGROUND')
    Background:SetAllPoints(Power)
    Background:SetTexture(1, 1, 1, .5)
-   
+
    -- Options
    Power.frequentUpdates = true
    Power.colorTapping = true
@@ -84,10 +84,10 @@
    Power.colorPower = true
    Power.colorClass = true
    Power.colorReaction = true
-   
+
    -- Make the background darker.
    Background.multiplier = .5
-   
+
    -- Register it with oUF
    self.Power = Power
    self.Power.bg = Background

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -208,7 +208,7 @@ local Update = function(self, event, unit)
 	end
 
 	t = self.colors.power[ptoken or ptype]
-	local atlas = power.atlas or t.atlas
+	local atlas = power.atlas or (t and t.atlas)
 	if(power.useAtlas and atlas and displayType ~= ALTERNATE_POWER_INDEX) then
 		power:SetStatusBarAtlas(atlas)
 		power:SetStatusBarColor(1, 1, 1)
@@ -216,7 +216,7 @@ local Update = function(self, event, unit)
 			t = disconnected and self.colors.disconnected or self.colors.tapped
 			power:GetStatusBarTexture():SetDesaturated(disconnected or tapped)
 		end
-		if(b) then
+		if(t and b) then
 			r, g, b = t[1], t[2], t[3]
 		end
 	else

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -21,6 +21,10 @@
  .displayAltPower   - Use this to let the widget display alternate power if the
                       unit has one. If no alternate power the display will fall
                       back to primary power.
+ .useAtlas          - Use this to let the widget use an atlas for its texture if
+                      `.atlas` is defined on the widget or an atlas is present in
+                      `self.colors.power` for the appropriate power type.
+ .atlas             - A custom atlas
 
  The following options are listed by priority. The first check that returns
  true decides the color of the bar.
@@ -108,7 +112,7 @@ for power, color in next, PowerBarColor do
 				oUF.colors.power[power][index] = {color.r, color.g, color.b}
 			end
 		else
-			oUF.colors.power[power] = {color.r, color.g, color.b}
+			oUF.colors.power[power] = {color.r, color.g, color.b, atlas = color.atlas}
 		end
 	end
 end
@@ -150,6 +154,7 @@ local Update = function(self, event, unit)
 	end
 	local cur, max = UnitPower(unit, displayType), UnitPowerMax(unit, displayType)
 	local disconnected = not UnitIsConnected(unit)
+	local tapped = not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)
 	power:SetMinMaxValues(min or 0, max)
 
 	if(disconnected) then
@@ -159,7 +164,9 @@ local Update = function(self, event, unit)
 	end
 
 	power.disconnected = disconnected
+	power.tapped = tapped
 
+	local ptype, ptoken, altR, altG, altB = UnitPowerType(unit)
 	local r, g, b, t
 
 	if(power.colorTapping and not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)) then
@@ -169,8 +176,6 @@ local Update = function(self, event, unit)
 	elseif(displayType == ALTERNATE_POWER_INDEX and power.altPowerColor) then
 		t = power.altPowerColor
 	elseif(power.colorPower) then
-		local ptype, ptoken, altR, altG, altB = UnitPowerType(unit)
-
 		t = self.colors.power[ptoken]
 		if(not t) then
 			if(power.GetAlternativeColor) then
@@ -194,7 +199,7 @@ local Update = function(self, event, unit)
 	elseif(power.colorReaction and UnitReaction(unit, 'player')) then
 		t = self.colors.reaction[UnitReaction(unit, "player")]
 	elseif(power.colorSmooth) then
-        local adjust = 0 - (min or 0)
+		local adjust = 0 - (min or 0)
 		r, g, b = self.ColorGradient(cur + adjust, max + adjust, unpack(power.smoothGradient or self.colors.smooth))
 	end
 
@@ -202,18 +207,33 @@ local Update = function(self, event, unit)
 		r, g, b = t[1], t[2], t[3]
 	end
 
-	if(b) then
-		power:SetStatusBarColor(r, g, b)
-
-		local bg = power.bg
-		if(bg) then
-			local mu = bg.multiplier or 1
-			bg:SetVertexColor(r * mu, g * mu, b * mu)
+	t = self.colors.power[ptoken or ptype]
+	local atlas = power.atlas or t.atlas
+	if(power.useAtlas and atlas and displayType ~= ALTERNATE_POWER_INDEX) then
+		power:SetStatusBarAtlas(atlas)
+		power:SetStatusBarColor(1, 1, 1)
+		if(power.colorTapping or power.colorDisconnected) then
+			t = disconnected and self.colors.disconnected or self.colors.tapped
+			power:GetStatusBarTexture():SetDesaturated(disconnected or tapped)
+		end
+		if(b) then
+			r, g, b = t[1], t[2], t[3]
+		end
+	else
+		power:SetStatusBarTexture(power.texture)
+		if(b) then
+			power:SetStatusBarColor(r, g, b)
 		end
 	end
 
+	local bg = power.bg
+	if(bg and b) then
+		local mu = bg.multiplier or 1
+		bg:SetVertexColor(r * mu, g * mu, b * mu)
+	end
+
 	if(power.PostUpdate) then
-		return power:PostUpdate(unit, cur, max, min)
+		return power:PostUpdate(unit, cur, max, min, ptoken, ptype)
 	end
 end
 
@@ -246,8 +266,9 @@ local Enable = function(self, unit)
 		-- For tapping.
 		self:RegisterEvent('UNIT_FACTION', Path)
 
-		if(power:IsObjectType'StatusBar' and not power:GetStatusBarTexture()) then
-			power:SetStatusBarTexture[[Interface\TargetingFrame\UI-StatusBar]]
+		if(power:IsObjectType'StatusBar') then
+			power.texture = power:GetStatusBarTexture() and power:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
+			power:SetStatusBarTexture(power.texture)
 		end
 
 		return true


### PR DESCRIPTION
Another attempt on #286 

~~**Issues:**~~
~~I was not able to unset the atlas once it was set, despite following [blizzard's code](https://github.com/Gethe/wow-ui-source/blob/live/FrameXML/UnitFrame.lua#L486-L498). Also tried `power:SetStatusBarAtlas(nil)` which made `power:GetStatusBarAtlas()` return nil but it didn't change anything (btw `power:SetStatusBarAtlas()` errors, nil is required like in `:SetTexture`). So I must be missing something here, but don't know what.~~
~~To reproduce:~~
  1. ~~set `Power.useAtlas` to true for the target frame in your layout~~
  2. ~~create a demon hunter~~
  3. ~~target yourself and then switch target to a normal mob (with a power resource not using an atlas)~~

**Limitations:**
All the coloring options in the power element could not be applied to atlases as the results depend on the color of the atlas.

**Notes:**
Atlases could be actually handled by the layout. To better support that we could just pass `ptoken` and `ptype` to PostUpdate and copy atlas information to the oUF.colors.power. ~~However the issue with unsetting the atlas remains.~~