### PR TITLE
core: Make sure UpdateAllElements has an event

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -145,7 +145,7 @@ for k, v in pairs{
 		local unit = self.unit
 		if(not UnitExists(unit)) then return end
 
-		assert(type(event) == 'string', 'Missing argument "event" in UpdateAllElements.')
+		assert(type(event) == 'string', 'Invalid argument "event" in UpdateAllElements.')
 
 		if(self.PreUpdate) then
 			self:PreUpdate(event)

--- a/ouf.lua
+++ b/ouf.lua
@@ -145,6 +145,8 @@ for k, v in pairs{
 		local unit = self.unit
 		if(not UnitExists(unit)) then return end
 
+		assert(type(event) == 'string', 'Missing argument "event" in UpdateAllElements.')
+
 		if(self.PreUpdate) then
 			self:PreUpdate(event)
 		end


### PR DESCRIPTION
Not providing events when calling UAE from 3rd-party sources
makes it very hard to debug should something go wrong.

Relevant issue: https://github.com/oUF-wow/oUF/issues/297#issuecomment-246696419.