### PR TITLE
core: Change the framestrata to LOW

### DIFF
--- a/oUF.xml
+++ b/oUF.xml
@@ -48,7 +48,7 @@
 	</Button>
 
 	<!-- Pet Battle Hider Frame -->
-	<Frame name="oUF_PetBattleFrameHider" inherits="SecureHandlerStateTemplate" parent="UIParent" setAllPoints="true">
+	<Frame name="oUF_PetBattleFrameHider" frameStrata="LOW" inherits="SecureHandlerStateTemplate" parent="UIParent" setAllPoints="true">
 		<Scripts>
 			<OnLoad>
 				RegisterStateDriver(self, "visibility", "[petbattle] hide; show")


### PR DESCRIPTION
This should make every unitframe have low framestrata instead of medium (like the default unitframes), so it doesn't overlap certain windows like garrision stuff for example.

