### PR TITLE
runebar: Set cooldown start time to 0 if rune was energised

### DIFF
--- a/elements/runebar.lua
+++ b/elements/runebar.lua
@@ -83,7 +83,7 @@ local Update = function(self, event, rid, energized)
 	end
 
 	if(runes.PostUpdate) then
-		return runes:PostUpdate(rune, rid, start, duration, energized or runeReady)
+		return runes:PostUpdate(rune, rid, energized and 0 or start, duration, energized or runeReady)
 	end
 end
 


### PR DESCRIPTION
When CD ends, start time is set to 0, however it doesn't happen, when rune is energised, so we pass wrong info to layout, cuz we don't differentiate between these two events.

Proof:
![image](https://cloud.githubusercontent.com/assets/2725970/18975665/03c690ec-86d6-11e6-9f7e-204c6fa330e3.png)