### PR TITLE
castbar: add a .holdTime option

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -111,7 +111,7 @@ local UNIT_SPELLCAST_START = function(self, event, unit, spell)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
-	local name, _, text, texture, startTime, endTime, _, castid, interrupt = UnitCastingInfo(unit)
+	local name, _, text, texture, startTime, endTime, _, castid, notInterruptible = UnitCastingInfo(unit)
 	if(not name) then
 		castbar:Hide()
 		return
@@ -126,7 +126,8 @@ local UNIT_SPELLCAST_START = function(self, event, unit, spell)
 	castbar.max = max
 	castbar.delay = 0
 	castbar.casting = true
-	castbar.interrupt = interrupt
+	castbar.interrupt = notInterruptible -- NOTE: deprecated; to be removed
+	castbar.notInterruptible = notInterruptible
 	castbar.holdTime = 0
 
 	castbar:SetMinMaxValues(0, max)
@@ -137,7 +138,7 @@ local UNIT_SPELLCAST_START = function(self, event, unit, spell)
 	if(castbar.Time) then castbar.Time:SetText() end
 
 	local shield = castbar.Shield
-	if(shield and interrupt) then
+	if(shield and notInterruptible) then
 		shield:Show()
 	elseif(shield) then
 		shield:Hide()
@@ -167,7 +168,8 @@ local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid)
 	end
 
 	castbar.casting = nil
-	castbar.interrupt = nil
+	castbar.interrupt = nil -- NOTE: deprecated; to be removed
+	castbar.notInterruptible = nil
 	castbar:SetValue(0)
 	castbar:Hide()
 
@@ -251,7 +253,8 @@ local UNIT_SPELLCAST_STOP = function(self, event, unit, spellname, _, castid)
 	end
 
 	castbar.casting = nil
-	castbar.interrupt = nil
+	castbar.interrupt = nil -- NOTE: deprecated; to be removed
+	castbar.notInterruptible = nil
 	castbar:SetValue(0)
 	castbar:Hide()
 
@@ -264,7 +267,7 @@ local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit, spellname)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
-	local name, _, text, texture, startTime, endTime, isTrade, interrupt = UnitChannelInfo(unit)
+	local name, _, text, texture, startTime, endTime, isTrade, notInterruptible = UnitChannelInfo(unit)
 	if(not name) then
 		return
 	end
@@ -278,7 +281,8 @@ local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit, spellname)
 	castbar.max = max
 	castbar.delay = 0
 	castbar.channeling = true
-	castbar.interrupt = interrupt
+	castbar.interrupt = notInterruptible -- NOTE: deprecated; to be removed
+	castbar.notInterruptible = notInterruptible
 	castbar.holdTime = 0
 
 	-- We have to do this, as it's possible for spell casts to never have _STOP
@@ -295,7 +299,7 @@ local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit, spellname)
 	if(castbar.Time) then castbar.Time:SetText() end
 
 	local shield = castbar.Shield
-	if(shield and interrupt) then
+	if(shield and notInterruptible) then
 		shield:Show()
 	elseif(shield) then
 		shield:Hide()
@@ -343,7 +347,8 @@ local UNIT_SPELLCAST_CHANNEL_STOP = function(self, event, unit, spellname)
 	local castbar = self.Castbar
 	if(castbar:IsShown()) then
 		castbar.channeling = nil
-		castbar.interrupt = nil
+		castbar.interrupt = nil -- NOTE: deprecated; to be removed
+		castbar.notInterruptible = nil
 
 		castbar:SetValue(castbar.max)
 		castbar:Hide()

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -17,9 +17,8 @@
 
  Options
 
- .holdTime - A Number to indicate for how long the castbar should be visible
-             after a _FAILED or _INTERRUPTED event. This value will be
-             compared to the return of `GetTime()`. Defaults to 0.
+ .timeToHold - A Number to indicate for how many seconds the castbar should be
+               visible after a _FAILED or _INTERRUPTED event. Defaults to 0.
 
  Credits
 
@@ -174,6 +173,7 @@ local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid, 
 	castbar.casting = nil
 	castbar.interrupt = nil -- NOTE: deprecated; to be removed
 	castbar.notInterruptible = nil
+	castbar.holdTime = castbar.timeToHold or 0
 
 	if(castbar.PostCastFailed) then
 		return castbar:PostCastFailed(unit, spellname, castid, spellid)
@@ -195,6 +195,7 @@ local UNIT_SPELLCAST_INTERRUPTED = function(self, event, unit, spellname, _, cas
 
 	castbar.casting = nil
 	castbar.channeling = nil
+	castbar.holdTime = castbar.timeToHold or 0
 
 	if(castbar.PostCastInterrupted) then
 		return castbar:PostCastInterrupted(unit, spellname, castid, spellid)
@@ -430,8 +431,8 @@ local onUpdate = function(self, elapsed)
 		if(self.Spark) then
 			self.Spark:SetPoint("CENTER", self, "LEFT", (duration / self.max) * self:GetWidth(), 0)
 		end
-	elseif(GetTime() < self.holdTime) then
-		return
+	elseif(self.holdTime > 0) then
+		self.holdTime = self.holdTime - elapsed
 	else
 		self.casting = nil
 		self.castid = nil

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -490,7 +490,7 @@ local Enable = function(object, unit)
 
 		local sz = castbar.SafeZone
 		if(sz and sz:IsObjectType'Texture' and not sz:GetTexture()) then
-			sz:SetTexture(1, 0, 0)
+			sz:SetColorTexture(1, 0, 0)
 		end
 
 		castbar:Hide()

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -82,10 +82,9 @@
  Hooks and Callbacks
 
 ]]
-local parent, ns = ...
+local _, ns = ...
 local oUF = ns.oUF
 
-local UnitName = UnitName
 local GetTime = GetTime
 local UnitCastingInfo = UnitCastingInfo
 local UnitChannelInfo = UnitChannelInfo
@@ -107,7 +106,7 @@ local updateSafeZone = function(self)
 	end
 end
 
-local UNIT_SPELLCAST_START = function(self, event, unit, spell)
+local UNIT_SPELLCAST_START = function(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -224,11 +223,11 @@ local UNIT_SPELLCAST_NOT_INTERRUPTIBLE = function(self, event, unit)
 	end
 end
 
-local UNIT_SPELLCAST_DELAYED = function(self, event, unit, spellname, _, castid)
+local UNIT_SPELLCAST_DELAYED = function(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
-	local name, _, text, texture, startTime, endTime = UnitCastingInfo(unit)
+	local name, _, _, _, startTime, _, _, castid = UnitCastingInfo(unit)
 	if(not startTime or not castbar:IsShown()) then return end
 
 	local duration = GetTime() - (startTime / 1000)
@@ -263,11 +262,11 @@ local UNIT_SPELLCAST_STOP = function(self, event, unit, spellname, _, castid)
 	end
 end
 
-local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit, spellname)
+local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
-	local name, _, text, texture, startTime, endTime, isTrade, notInterruptible = UnitChannelInfo(unit)
+	local name, _, _, texture, startTime, endTime, _, notInterruptible = UnitChannelInfo(unit)
 	if(not name) then
 		return
 	end
@@ -318,11 +317,11 @@ local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit, spellname)
 	castbar:Show()
 end
 
-local UNIT_SPELLCAST_CHANNEL_UPDATE = function(self, event, unit, spellname)
+local UNIT_SPELLCAST_CHANNEL_UPDATE = function(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
-	local name, _, text, texture, startTime, endTime, oldStart = UnitChannelInfo(unit)
+	local name, _, _, _, startTime, endTime = UnitChannelInfo(unit)
 	if(not name or not castbar:IsShown()) then
 		return
 	end
@@ -427,7 +426,6 @@ local onUpdate = function(self, elapsed)
 	elseif(GetTime() < self.holdTime) then
 		return
 	else
-		self.unitName = nil
 		self.casting = nil
 		self.castid = nil
 		self.channeling = nil
@@ -504,7 +502,7 @@ local Enable = function(object, unit)
 	end
 end
 
-local Disable = function(object, unit)
+local Disable = function(object)
 	local castbar = object.Castbar
 
 	if(castbar) then

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -111,7 +111,7 @@ local UNIT_SPELLCAST_START = function(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
-	local name, _, text, texture, startTime, endTime, _, castid, notInterruptible = UnitCastingInfo(unit)
+	local name, _, text, texture, startTime, endTime, _, castid, notInterruptible, spellid = UnitCastingInfo(unit)
 	if(not name) then
 		return castbar:Hide()
 	end
@@ -153,12 +153,12 @@ local UNIT_SPELLCAST_START = function(self, event, unit)
 	end
 
 	if(castbar.PostCastStart) then
-		castbar:PostCastStart(unit, name, castid)
+		castbar:PostCastStart(unit, name, castid, spellid)
 	end
 	castbar:Show()
 end
 
-local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid)
+local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -176,11 +176,11 @@ local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid)
 	castbar.notInterruptible = nil
 
 	if(castbar.PostCastFailed) then
-		return castbar:PostCastFailed(unit, spellname, castid)
+		return castbar:PostCastFailed(unit, spellname, castid, spellid)
 	end
 end
 
-local UNIT_SPELLCAST_INTERRUPTED = function(self, event, unit, spellname, _, castid)
+local UNIT_SPELLCAST_INTERRUPTED = function(self, event, unit, spellname, _, castid, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -197,7 +197,7 @@ local UNIT_SPELLCAST_INTERRUPTED = function(self, event, unit, spellname, _, cas
 	castbar.channeling = nil
 
 	if(castbar.PostCastInterrupted) then
-		return castbar:PostCastInterrupted(unit, spellname, castid)
+		return castbar:PostCastInterrupted(unit, spellname, castid, spellid)
 	end
 end
 
@@ -235,7 +235,7 @@ local UNIT_SPELLCAST_NOT_INTERRUPTIBLE = function(self, event, unit)
 	end
 end
 
-local UNIT_SPELLCAST_DELAYED = function(self, event, unit)
+local UNIT_SPELLCAST_DELAYED = function(self, event, unit, _, _, _, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -251,11 +251,11 @@ local UNIT_SPELLCAST_DELAYED = function(self, event, unit)
 	castbar:SetValue(duration)
 
 	if(castbar.PostCastDelayed) then
-		return castbar:PostCastDelayed(unit, name, castid)
+		return castbar:PostCastDelayed(unit, name, castid, spellid)
 	end
 end
 
-local UNIT_SPELLCAST_STOP = function(self, event, unit, spellname, _, castid)
+local UNIT_SPELLCAST_STOP = function(self, event, unit, spellname, _, castid, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -268,11 +268,11 @@ local UNIT_SPELLCAST_STOP = function(self, event, unit, spellname, _, castid)
 	castbar.notInterruptible = nil
 
 	if(castbar.PostCastStop) then
-		return castbar:PostCastStop(unit, spellname, castid)
+		return castbar:PostCastStop(unit, spellname, castid, spellid)
 	end
 end
 
-local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit)
+local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit, _, _, _, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -323,11 +323,11 @@ local UNIT_SPELLCAST_CHANNEL_START = function(self, event, unit)
 		updateSafeZone(castbar)
 	end
 
-	if(castbar.PostChannelStart) then castbar:PostChannelStart(unit, name) end
+	if(castbar.PostChannelStart) then castbar:PostChannelStart(unit, name, spellid) end
 	castbar:Show()
 end
 
-local UNIT_SPELLCAST_CHANNEL_UPDATE = function(self, event, unit)
+local UNIT_SPELLCAST_CHANNEL_UPDATE = function(self, event, unit, _, _, _, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -346,11 +346,11 @@ local UNIT_SPELLCAST_CHANNEL_UPDATE = function(self, event, unit)
 	castbar:SetValue(duration)
 
 	if(castbar.PostChannelUpdate) then
-		return castbar:PostChannelUpdate(unit, name)
+		return castbar:PostChannelUpdate(unit, name, spellid)
 	end
 end
 
-local UNIT_SPELLCAST_CHANNEL_STOP = function(self, event, unit, spellname)
+local UNIT_SPELLCAST_CHANNEL_STOP = function(self, event, unit, spellname, _, _, spellid)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local castbar = self.Castbar
@@ -360,7 +360,7 @@ local UNIT_SPELLCAST_CHANNEL_STOP = function(self, event, unit, spellname)
 		castbar.notInterruptible = nil
 
 		if(castbar.PostChannelStop) then
-			return castbar:PostChannelStop(unit, spellname)
+			return castbar:PostChannelStop(unit, spellname, spellid)
 		end
 	end
 end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -113,8 +113,7 @@ local UNIT_SPELLCAST_START = function(self, event, unit)
 	local castbar = self.Castbar
 	local name, _, text, texture, startTime, endTime, _, castid, notInterruptible = UnitCastingInfo(unit)
 	if(not name) then
-		castbar:Hide()
-		return
+		return castbar:Hide()
 	end
 
 	endTime = endTime / 1e3
@@ -170,8 +169,6 @@ local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid)
 	castbar.casting = nil
 	castbar.interrupt = nil -- NOTE: deprecated; to be removed
 	castbar.notInterruptible = nil
-	castbar:SetValue(0)
-	castbar:Hide()
 
 	if(castbar.PostCastFailed) then
 		return castbar:PostCastFailed(unit, spellname, castid)
@@ -185,11 +182,9 @@ local UNIT_SPELLCAST_INTERRUPTED = function(self, event, unit, spellname, _, cas
 	if(castbar.castid ~= castid) then
 		return
 	end
+
 	castbar.casting = nil
 	castbar.channeling = nil
-
-	castbar:SetValue(0)
-	castbar:Hide()
 
 	if(castbar.PostCastInterrupted) then
 		return castbar:PostCastInterrupted(unit, spellname, castid)
@@ -261,8 +256,6 @@ local UNIT_SPELLCAST_STOP = function(self, event, unit, spellname, _, castid)
 	castbar.casting = nil
 	castbar.interrupt = nil -- NOTE: deprecated; to be removed
 	castbar.notInterruptible = nil
-	castbar:SetValue(0)
-	castbar:Hide()
 
 	if(castbar.PostCastStop) then
 		return castbar:PostCastStop(unit, spellname, castid)
@@ -356,9 +349,6 @@ local UNIT_SPELLCAST_CHANNEL_STOP = function(self, event, unit, spellname)
 		castbar.interrupt = nil -- NOTE: deprecated; to be removed
 		castbar.notInterruptible = nil
 
-		castbar:SetValue(castbar.max)
-		castbar:Hide()
-
 		if(castbar.PostChannelStop) then
 			return castbar:PostChannelStop(unit, spellname)
 		end
@@ -437,7 +427,6 @@ local onUpdate = function(self, elapsed)
 		self.castid = nil
 		self.channeling = nil
 
-		self:SetValue(1)
 		self:Hide()
 	end
 end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -166,6 +166,11 @@ local UNIT_SPELLCAST_FAILED = function(self, event, unit, spellname, _, castid)
 		return
 	end
 
+	local text = castbar.Text
+	if(text) then
+		text:SetText(FAILED)
+	end
+
 	castbar.casting = nil
 	castbar.interrupt = nil -- NOTE: deprecated; to be removed
 	castbar.notInterruptible = nil
@@ -181,6 +186,11 @@ local UNIT_SPELLCAST_INTERRUPTED = function(self, event, unit, spellname, _, cas
 	local castbar = self.Castbar
 	if(castbar.castid ~= castid) then
 		return
+	end
+
+	local text = castbar.Text
+	if(text) then
+		text:SetText(INTERRUPTED)
 	end
 
 	castbar.casting = nil

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -205,6 +205,9 @@ local UNIT_SPELLCAST_INTERRUPTIBLE = function(self, event, unit)
 		shield:Hide()
 	end
 
+	castbar.interrupt = nil -- NOTE: deprecated; to be removed
+	castbar.notInterruptible = nil
+
 	if(castbar.PostCastInterruptible) then
 		return castbar:PostCastInterruptible(unit)
 	end
@@ -218,6 +221,9 @@ local UNIT_SPELLCAST_NOT_INTERRUPTIBLE = function(self, event, unit)
 	if(shield) then
 		shield:Show()
 	end
+
+	castbar.interrupt = true -- NOTE: deprecated; to be removed
+	castbar.notInterruptible = true
 
 	if(castbar.PostCastNotInterruptible) then
 		return castbar:PostCastNotInterruptible(unit)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -85,6 +85,7 @@
 local _, ns = ...
 local oUF = ns.oUF
 
+local GetNetStats = GetNetStats
 local GetTime = GetTime
 local UnitCastingInfo = UnitCastingInfo
 local UnitChannelInfo = UnitChannelInfo

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -444,30 +444,30 @@ local ForceUpdate = function(element)
 	return Update(element.__owner, 'ForceUpdate', element.__owner.unit)
 end
 
-local Enable = function(object, unit)
-	local castbar = object.Castbar
+local Enable = function(self, unit)
+	local castbar = self.Castbar
 
 	if(castbar) then
-		castbar.__owner = object
+		castbar.__owner = self
 		castbar.ForceUpdate = ForceUpdate
 
 		if(not (unit and unit:match'%wtarget$')) then
-			object:RegisterEvent("UNIT_SPELLCAST_START", UNIT_SPELLCAST_START)
-			object:RegisterEvent("UNIT_SPELLCAST_FAILED", UNIT_SPELLCAST_FAILED)
-			object:RegisterEvent("UNIT_SPELLCAST_STOP", UNIT_SPELLCAST_STOP)
-			object:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED", UNIT_SPELLCAST_INTERRUPTED)
-			object:RegisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE", UNIT_SPELLCAST_INTERRUPTIBLE)
-			object:RegisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE", UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
-			object:RegisterEvent("UNIT_SPELLCAST_DELAYED", UNIT_SPELLCAST_DELAYED)
-			object:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START", UNIT_SPELLCAST_CHANNEL_START)
-			object:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE", UNIT_SPELLCAST_CHANNEL_UPDATE)
-			object:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP", UNIT_SPELLCAST_CHANNEL_STOP)
+			self:RegisterEvent("UNIT_SPELLCAST_START", UNIT_SPELLCAST_START)
+			self:RegisterEvent("UNIT_SPELLCAST_FAILED", UNIT_SPELLCAST_FAILED)
+			self:RegisterEvent("UNIT_SPELLCAST_STOP", UNIT_SPELLCAST_STOP)
+			self:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED", UNIT_SPELLCAST_INTERRUPTED)
+			self:RegisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE", UNIT_SPELLCAST_INTERRUPTIBLE)
+			self:RegisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE", UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
+			self:RegisterEvent("UNIT_SPELLCAST_DELAYED", UNIT_SPELLCAST_DELAYED)
+			self:RegisterEvent("UNIT_SPELLCAST_CHANNEL_START", UNIT_SPELLCAST_CHANNEL_START)
+			self:RegisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE", UNIT_SPELLCAST_CHANNEL_UPDATE)
+			self:RegisterEvent("UNIT_SPELLCAST_CHANNEL_STOP", UNIT_SPELLCAST_CHANNEL_STOP)
 		end
 
 		castbar.holdTime = 0
 		castbar:SetScript("OnUpdate", castbar.OnUpdate or onUpdate)
 
-		if(object.unit == "player") then
+		if(self.unit == "player") then
 			CastingBarFrame:UnregisterAllEvents()
 			CastingBarFrame.Show = CastingBarFrame.Hide
 			CastingBarFrame:Hide()
@@ -502,21 +502,21 @@ local Enable = function(object, unit)
 	end
 end
 
-local Disable = function(object)
-	local castbar = object.Castbar
+local Disable = function(self)
+	local castbar = self.Castbar
 
 	if(castbar) then
 		castbar:Hide()
-		object:UnregisterEvent("UNIT_SPELLCAST_START", UNIT_SPELLCAST_START)
-		object:UnregisterEvent("UNIT_SPELLCAST_FAILED", UNIT_SPELLCAST_FAILED)
-		object:UnregisterEvent("UNIT_SPELLCAST_STOP", UNIT_SPELLCAST_STOP)
-		object:UnregisterEvent("UNIT_SPELLCAST_INTERRUPTED", UNIT_SPELLCAST_INTERRUPTED)
-		object:UnregisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE", UNIT_SPELLCAST_INTERRUPTIBLE)
-		object:UnregisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE", UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
-		object:UnregisterEvent("UNIT_SPELLCAST_DELAYED", UNIT_SPELLCAST_DELAYED)
-		object:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_START", UNIT_SPELLCAST_CHANNEL_START)
-		object:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE", UNIT_SPELLCAST_CHANNEL_UPDATE)
-		object:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_STOP", UNIT_SPELLCAST_CHANNEL_STOP)
+		self:UnregisterEvent("UNIT_SPELLCAST_START", UNIT_SPELLCAST_START)
+		self:UnregisterEvent("UNIT_SPELLCAST_FAILED", UNIT_SPELLCAST_FAILED)
+		self:UnregisterEvent("UNIT_SPELLCAST_STOP", UNIT_SPELLCAST_STOP)
+		self:UnregisterEvent("UNIT_SPELLCAST_INTERRUPTED", UNIT_SPELLCAST_INTERRUPTED)
+		self:UnregisterEvent("UNIT_SPELLCAST_INTERRUPTIBLE", UNIT_SPELLCAST_INTERRUPTIBLE)
+		self:UnregisterEvent("UNIT_SPELLCAST_NOT_INTERRUPTIBLE", UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
+		self:UnregisterEvent("UNIT_SPELLCAST_DELAYED", UNIT_SPELLCAST_DELAYED)
+		self:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_START", UNIT_SPELLCAST_CHANNEL_START)
+		self:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_UPDATE", UNIT_SPELLCAST_CHANNEL_UPDATE)
+		self:UnregisterEvent("UNIT_SPELLCAST_CHANNEL_STOP", UNIT_SPELLCAST_CHANNEL_STOP)
 
 		castbar:SetScript("OnUpdate", nil)
 	end


### PR DESCRIPTION
Also use `SetColorTexture` instead of `SetTexture` for setting the color.

This is the minimal approach so that nothing changes for current implementations layout wise,

However it is not optimal. The way to use it is to set `Castbar.holdTime` to `GetTime() + CONSTANT` in both `Castbar.PostCastFailed` and `Castbar.PostCastInterrupted` and show the castbar again. The user can also update the castbar text and max value if desired. Also, with the current behavior the bar will be hidden first (UNIT_SPELLCAST_STOP fires after the first UNIT_SPELLCAST_INTTERUPTED, which fires 4 times).

A more intuitive approach would be to handle this from the default element (including setting the castbar text to `_G.INTERRUPTED`/`_G.FAILED` to mimic the default UI) and leave the castbar hiding to the OnUpdate script.

What do you think?

PS: `Castbar.interrupt` actually meaning `Castbar.notInterruptible` drives me crazy :)