### PR TITLE
GetCreatureDifficultyColor and 199

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -34,7 +34,7 @@ local tagStrings = {
 	["difficulty"] = [[function(u)
 		if UnitCanAttack("player", u) then
 			local l = UnitLevel(u)
-			return Hex(GetQuestDifficultyColor((l > 0) and l or 99))
+			return Hex(GetCreatureDifficultyColor((l > 0) and l or 199))
 		end
 	end]],
 


### PR DESCRIPTION
QuestDifficultyColor does not scale with timewalking dungeons.
99 is outdated for the unknown max level. Use 199 instead.