### PR TITLE
Ignore health updates with nil unit (Blizz bug in 7.1)

### DIFF
--- a/elements/health.lua
+++ b/elements/health.lua
@@ -89,7 +89,7 @@ local oUF = ns.oUF
 oUF.colors.health = {49/255, 207/255, 37/255}
 
 local Update = function(self, event, unit)
-	if(self.unit ~= unit) then return end
+	if(not unit or self.unit ~= unit) then return end
 	local health = self.Health
 
 	if(health.PreUpdate) then health:PreUpdate(unit) end


### PR DESCRIPTION
In 7.1, UNIT_HEALTH and UNIT_MAXHEALTH sometimes fire with `nil` in place of a unit token. oUF should just skip any attempt at updating the Health element when this happens, so layouts don't need to add their own checks to avoid errors. The existing `if (self.unit ~= unit)` check isn't sufficient, because `self.unit` is naturally `nil` on header-spawned frames whose unit doesn't currently exist (eg. join a party with 4 players, have someone leave the group, the 4th party frame is hidden but still exists and has no `unit` key).