### PR TITLE
core: Expose header visibility

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -532,9 +532,11 @@ do
 			local type, list = string.split(' ', visibility, 2)
 			if(list and type == 'custom') then
 				RegisterAttributeDriver(header, 'state-visibility', list)
+				header.visibility = list
 			else
 				local condition = getCondition(string.split(',', visibility))
 				RegisterAttributeDriver(header, 'state-visibility', condition)
+				header.visibility = condition
 			end
 		end
 


### PR DESCRIPTION
Unless anyone knows a way of getting this without exposing it here, SecureStateDriver is pretty air-tight.