### PR TITLE
Feature: oUF NamePlates

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -1,7 +1,8 @@
 local parent, ns = ...
 local oUF = ns.oUF
 
-local hiddenParent = CreateFrame('Frame')
+local hiddenParent = CreateFrame('Frame', nil, UIParent)
+hiddenParent:SetAllPoints()
 hiddenParent:Hide()
 
 local function handleFrame(baseName)
@@ -19,7 +20,7 @@ local function handleFrame(baseName)
 		-- Keep frame hidden without causing taint
 		frame:SetParent(hiddenParent)
 
-		local health = frame.healthbar
+		local health = frame.healthBar or frame.healthbar
 		if(health) then
 			health:UnregisterAllEvents()
 		end
@@ -29,7 +30,7 @@ local function handleFrame(baseName)
 			power:UnregisterAllEvents()
 		end
 
-		local spell = frame.spellbar
+		local spell = frame.castBar or frame.spellbar
 		if(spell) then
 			spell:UnregisterAllEvents()
 		end
@@ -98,5 +99,10 @@ function oUF:DisableBlizzard(unit)
 		-- Blizzard_ArenaUI should not be loaded
 		Arena_LoadUI = function() end
 		SetCVar('showArenaEnemyFrames', '0', 'SHOW_ARENA_ENEMY_FRAMES_TEXT')
+	elseif(unit:match('(nameplate)%d*$') == 'nameplate') then
+		local frame = C_NamePlate.GetNamePlateForUnit(unit)
+		if(frame and frame.UnitFrame) then
+			handleFrame(frame.UnitFrame)
+		end
 	end
 end

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -73,7 +73,7 @@ function oUF:DisableBlizzard(unit)
 		handleFrame(TargetofFocusFrame)
 	elseif(unit == 'targettarget') then
 		handleFrame(TargetFrameToT)
-	elseif(unit:match('(boss)%d?$') == 'boss') then
+	elseif(unit:match('boss%d?$')) then
 		local id = unit:match('boss(%d)')
 		if(id) then
 			handleFrame('Boss' .. id .. 'TargetFrame')
@@ -82,7 +82,7 @@ function oUF:DisableBlizzard(unit)
 				handleFrame(string.format('Boss%dTargetFrame', i))
 			end
 		end
-	elseif(unit:match('(party)%d?$') == 'party') then
+	elseif(unit:match('party%d?$')) then
 		local id = unit:match('party(%d)')
 		if(id) then
 			handleFrame('PartyMemberFrame' .. id)
@@ -91,7 +91,7 @@ function oUF:DisableBlizzard(unit)
 				handleFrame(string.format('PartyMemberFrame%d', i))
 			end
 		end
-	elseif(unit:match('(arena)%d?$') == 'arena') then
+	elseif(unit:match('arena%d?$')) then
 		local id = unit:match('arena(%d)')
 		if(id) then
 			handleFrame('ArenaEnemyFrame' .. id)
@@ -104,7 +104,7 @@ function oUF:DisableBlizzard(unit)
 		-- Blizzard_ArenaUI should not be loaded
 		Arena_LoadUI = function() end
 		SetCVar('showArenaEnemyFrames', '0', 'SHOW_ARENA_ENEMY_FRAMES_TEXT')
-	elseif(unit:match('(nameplate)%d*$') == 'nameplate') then
+	elseif(unit:match('nameplate%d+$')) then
 		local frame = C_NamePlate.GetNamePlateForUnit(unit)
 		if(frame and frame.UnitFrame) then
 			handleFrame(frame.UnitFrame)

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -39,6 +39,11 @@ local function handleFrame(baseName)
 		if(altpowerbar) then
 			altpowerbar:UnregisterAllEvents()
 		end
+
+		local buffFrame = frame.BuffFrame
+		if(buffFrame) then
+			buffFrame:UnregisterAllEvents()
+		end
 	end
 end
 

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -74,7 +74,7 @@ function oUF:DisableBlizzard(unit)
 			handleFrame('Boss' .. id .. 'TargetFrame')
 		else
 			for i = 1, 5 do
-				handleFrame(('Boss%dTargetFrame'):format(i))
+				handleFrame(string.format('Boss%dTargetFrame', i))
 			end
 		end
 	elseif(unit:match('(party)%d?$') == 'party') then
@@ -83,7 +83,7 @@ function oUF:DisableBlizzard(unit)
 			handleFrame('PartyMemberFrame' .. id)
 		else
 			for i = 1, 4 do
-				handleFrame(('PartyMemberFrame%d'):format(i))
+				handleFrame(string.format('PartyMemberFrame%d', i))
 			end
 		end
 	elseif(unit:match('(arena)%d?$') == 'arena') then

--- a/ouf.lua
+++ b/ouf.lua
@@ -589,9 +589,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	eventHandler:RegisterEvent('PLAYER_TARGET_CHANGED')
 	eventHandler:RegisterEvent('PLAYER_LOGIN')
 	eventHandler:SetScript('OnEvent', function(_, event, unit)
-		if(event == 'PLAYER_LOGIN') then
-			if(not nameplateCVars) then return end
-
+		if(event == 'PLAYER_LOGIN' and nameplateCVars) then
 			for cvar, value in next, nameplateCVars do
 				SetCVar(cvar, value)
 			end

--- a/ouf.lua
+++ b/ouf.lua
@@ -579,14 +579,14 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 
 	NamePlateDriverFrame:Hide()
 	NamePlateDriverFrame:UnregisterAllEvents()
-	NamePlateDriverFrame:RegisterEvent("NAME_PLATE_CREATED")
-	NamePlateDriverFrame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
-	NamePlateDriverFrame:RegisterEvent("NAME_PLATE_UNIT_REMOVED")
-	NamePlateDriverFrame:HookScript("OnEvent", function(self, event, unit)
-		if(event == "NAME_PLATE_UNIT_ADDED") then
+	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_CREATED')
+	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_ADDED')
+	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_REMOVED')
+	NamePlateDriverFrame:HookScript('OnEvent', function(_, event, unit)
+		if(event == 'NAME_PLATE_UNIT_ADDED') then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 
-			if nameplate.UnitFrame then
+			if(nameplate.UnitFrame) then
 				nameplate.UnitFrame:SetParent(hiddenParent)
 			end
 		end

--- a/ouf.lua
+++ b/ouf.lua
@@ -574,6 +574,10 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	local style = style
 	local prefix = namePrefix or generateName()
 
+	-- There's no way to prevent nameplate settings updates without tainting UI,
+	-- thus we should allow default nameplate driver to create, update, and remove
+	-- Blizz nameplates. "Disabling" them via oUF:DisableBlizzard is a bit ugly,
+	-- but taint-free solution.
 	NamePlateDriverFrame:Hide()
 	NamePlateDriverFrame:UnregisterAllEvents()
 	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_CREATED')

--- a/ouf.lua
+++ b/ouf.lua
@@ -614,9 +614,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			if(nameplateCallback) then
 				nameplateCallback(event, nameplate)
 			end
-		elseif(event == 'NAME_PLATE_UNIT_ADDED') then
-			if(not unit) then return end
-
+		elseif(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
 
@@ -637,9 +635,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			if(nameplateCallback) then
 				nameplateCallback(event, nameplate, unit)
 			end
-		elseif(event == 'NAME_PLATE_UNIT_REMOVED') then
-			if(not unit) then return end
-
+		elseif(event == 'NAME_PLATE_UNIT_REMOVED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
 

--- a/ouf.lua
+++ b/ouf.lua
@@ -568,7 +568,11 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	argcheck(nameplateCallback, 3, 'function', 'nil')
 	argcheck(nameplateCVars, 4, 'table', 'nil')
 
-	-- disable blizzard nameplates
+	local style = style
+	if(not style) then return error('Unable to create frame. No styles have been registered.') end
+
+	local prefix = namePrefix or generateName()
+
 	NamePlateDriverFrame:UnregisterAllEvents()
 	NamePlateDriverFrame:Hide()
 	NamePlateDriverFrame.UpdateNamePlateOptions = function()
@@ -576,11 +580,6 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			nameplateCallback('UpdateNamePlateOptions')
 		end
 	end
-
-	local style = style
-	if(not style) then return error('Unable to create frame. No styles have been registered.') end
-
-	local prefix = namePrefix or generateName()
 
 	local eventHandler = CreateFrame('Frame')
 	eventHandler:RegisterEvent('NAME_PLATE_UNIT_ADDED')

--- a/ouf.lua
+++ b/ouf.lua
@@ -612,9 +612,9 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
 
-			nameplate.style = style
-
 			if(not nameplate.unitFrame) then
+				nameplate.style = style
+
 				nameplate.unitFrame = CreateFrame('Button', prefix..nameplate:GetName(), nameplate)
 				nameplate.unitFrame:EnableMouse(false)
 				nameplate.unitFrame.isNamePlate = true

--- a/ouf.lua
+++ b/ouf.lua
@@ -574,10 +574,10 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	local style = style
 	local prefix = namePrefix or generateName()
 
-	-- There's no way to prevent nameplate settings updates without tainting UI,
-	-- thus we should allow default nameplate driver to create, update, and remove
-	-- Blizz nameplates. "Disabling" them via oUF:DisableBlizzard is a bit ugly,
-	-- but taint-free solution.
+	-- Because there's no way to prevent nameplate settings updates without tainting UI,
+	-- and because forbidden nameplates exist, we have to allow default nameplate
+	-- driver to create, update, and remove Blizz nameplates.
+	-- Disable only not forbidden nameplates.
 	NamePlateDriverFrame:HookScript('OnEvent', function(_, event, unit)
 		if(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
 			self:DisableBlizzard(unit)

--- a/ouf.lua
+++ b/ouf.lua
@@ -566,8 +566,9 @@ function oUF:Spawn(unit, overrideName)
 	return object
 end
 
-function oUF:SpawnNamePlates(namePrefix, nameplateCVars)
-	argcheck(nameplateCVars, 3, 'table', 'nil')
+function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
+	argcheck(nameplateCallback, 3, 'function', 'nil')
+	argcheck(nameplateCVars, 4, 'table', 'nil')
 	if(not style) then return error('Unable to create frame. No styles have been registered.') end
 
 	local style = style
@@ -615,6 +616,10 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCVars)
 			if(not nameplate) then return end
 
 			nameplate.unitFrame:UpdateAllElements(event)
+
+			if(nameplateCallback) then
+				nameplateCallback(event, nameplate.unitFrame, 'target')
+			end
 		elseif(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
@@ -633,12 +638,20 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCVars)
 
 			nameplate.unitFrame:SetAttribute('unit', unit)
 			nameplate.unitFrame:UpdateAllElements(event)
+
+			if(nameplateCallback) then
+				nameplateCallback(event, nameplate.unitFrame, unit)
+			end
 		elseif(event == 'NAME_PLATE_UNIT_REMOVED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
 
 			nameplate.unitFrame:SetAttribute('unit', nil)
 			nameplate.unitFrame:UpdateAllElements(event)
+
+			if(nameplateCallback) then
+				nameplateCallback(event, nameplate.unitFrame, unit)
+			end
 		end
 	end)
 end

--- a/ouf.lua
+++ b/ouf.lua
@@ -566,9 +566,8 @@ function oUF:Spawn(unit, overrideName)
 	return object
 end
 
-function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
-	argcheck(nameplateCallback, 3, 'function', 'nil')
-	argcheck(nameplateCVars, 4, 'table', 'nil')
+function oUF:SpawnNamePlates(namePrefix, nameplateCVars)
+	argcheck(nameplateCVars, 3, 'table', 'nil')
 	if(not style) then return error('Unable to create frame. No styles have been registered.') end
 
 	local style = style
@@ -616,10 +615,6 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			if(not nameplate) then return end
 
 			nameplate.unitFrame:UpdateAllElements(event)
-
-			if(nameplateCallback) then
-				nameplateCallback(event, nameplate)
-			end
 		elseif(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
@@ -638,20 +633,12 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 
 			nameplate.unitFrame:SetAttribute('unit', unit)
 			nameplate.unitFrame:UpdateAllElements(event)
-
-			if(nameplateCallback) then
-				nameplateCallback(event, nameplate, unit)
-			end
 		elseif(event == 'NAME_PLATE_UNIT_REMOVED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
 
 			nameplate.unitFrame:SetAttribute('unit', nil)
 			nameplate.unitFrame:UpdateAllElements(event)
-
-			if(nameplateCallback) then
-				nameplateCallback(event, nameplate, unit)
-			end
 		end
 	end)
 end

--- a/ouf.lua
+++ b/ouf.lua
@@ -617,8 +617,6 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 		elseif(event == 'NAME_PLATE_UNIT_ADDED') then
 			if(not unit) then return end
 
-			unit = unit:lower()
-
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 			if(not nameplate) then return end
 

--- a/ouf.lua
+++ b/ouf.lua
@@ -595,10 +595,22 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	eventHandler:RegisterEvent('PLAYER_TARGET_CHANGED')
 	eventHandler:RegisterEvent('PLAYER_LOGIN')
 	eventHandler:SetScript('OnEvent', function(_, event, unit)
-		if(event == 'PLAYER_LOGIN' and nameplateCVars) then
-			for cvar, value in next, nameplateCVars do
-				SetCVar(cvar, value)
+		if(event == 'PLAYER_LOGIN') then
+			if(nameplateCVars) then
+				for cvar, value in next, nameplateCVars do
+					SetCVar(cvar, value)
+				end
 			end
+
+			-- Disable power and classpower bars.
+			ClassNameplateManaBarFrame:UnregisterAllEvents()
+			DeathKnightResourceOverlayFrame:UnregisterAllEvents()
+			ClassNameplateBarMageFrame:UnregisterAllEvents()
+			ClassNameplateBarWindwalkerMonkFrame:UnregisterAllEvents()
+			ClassNameplateBrewmasterBarFrame:UnregisterAllEvents()
+			ClassNameplateBarPaladinFrame:UnregisterAllEvents()
+			ClassNameplateBarRogueDruidFrame:UnregisterAllEvents()
+			ClassNameplateBarWarlockFrame:UnregisterAllEvents()
 		elseif(event == 'PLAYER_TARGET_CHANGED') then
 			local nameplate = C_NamePlate.GetNamePlateForUnit('target')
 			if(not nameplate) then return end

--- a/ouf.lua
+++ b/ouf.lua
@@ -584,6 +584,8 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_REMOVED')
 	NamePlateDriverFrame:HookScript('OnEvent', function(_, event, unit)
 		if(event == 'NAME_PLATE_UNIT_ADDED') then
+			if(not unit) then return end
+
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
 
 			if(nameplate.UnitFrame) then

--- a/ouf.lua
+++ b/ouf.lua
@@ -573,13 +573,24 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 
 	local prefix = namePrefix or generateName()
 
-	NamePlateDriverFrame:UnregisterAllEvents()
+	local hiddenParent = CreateFrame('Frame', nil, UIParent)
+	hiddenParent:SetAllPoints()
+	hiddenParent:Hide()
+
 	NamePlateDriverFrame:Hide()
-	NamePlateDriverFrame.UpdateNamePlateOptions = function()
-		if(nameplateCallback) then
-			nameplateCallback('UpdateNamePlateOptions')
+	NamePlateDriverFrame:UnregisterAllEvents()
+	NamePlateDriverFrame:RegisterEvent("NAME_PLATE_CREATED")
+	NamePlateDriverFrame:RegisterEvent("NAME_PLATE_UNIT_ADDED")
+	NamePlateDriverFrame:RegisterEvent("NAME_PLATE_UNIT_REMOVED")
+	NamePlateDriverFrame:HookScript("OnEvent", function(self, event, unit)
+		if(event == "NAME_PLATE_UNIT_ADDED") then
+			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
+
+			if nameplate.UnitFrame then
+				nameplate.UnitFrame:SetParent(hiddenParent)
+			end
 		end
-	end
+	end)
 
 	local eventHandler = CreateFrame('Frame')
 	eventHandler:RegisterEvent('NAME_PLATE_UNIT_ADDED')

--- a/ouf.lua
+++ b/ouf.lua
@@ -545,6 +545,18 @@ do
 	end
 end
 
+function oUF:SpawnNamePlate(unit, overrideName, nameplate)
+	argcheck(unit, 2, 'string')
+	if(not style) then return error("Unable to create frame. No styles have been registered.") end
+	unit = unit:lower()
+	local name = overrideName or generateName(unit)
+	local object = CreateFrame("Button", name, nameplate)
+	Private.UpdateUnits(object, unit)
+	walkObject(object, unit)
+	object:SetAttribute("unit", unit)
+	return object
+end
+
 function oUF:Spawn(unit, overrideName)
 	argcheck(unit, 2, 'string')
 	if(not style) then return error('Unable to create frame. No styles have been registered.') end

--- a/ouf.lua
+++ b/ouf.lua
@@ -567,10 +567,9 @@ end
 function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	argcheck(nameplateCallback, 3, 'function', 'nil')
 	argcheck(nameplateCVars, 4, 'table', 'nil')
-
-	local style = style
 	if(not style) then return error('Unable to create frame. No styles have been registered.') end
 
+	local style = style
 	local prefix = namePrefix or generateName()
 
 	local hiddenParent = CreateFrame('Frame', nil, UIParent)

--- a/ouf.lua
+++ b/ouf.lua
@@ -603,7 +603,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			nameplate.unitFrame:UpdateAllElements(event)
 
 			if(nameplateCallback) then
-				nameplateCallback(event, nameplate.unitFrame, 'target')
+				nameplateCallback(nameplate.unitFrame, event, 'target')
 			end
 		elseif(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
@@ -625,7 +625,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			nameplate.unitFrame:UpdateAllElements(event)
 
 			if(nameplateCallback) then
-				nameplateCallback(event, nameplate.unitFrame, unit)
+				nameplateCallback(nameplate.unitFrame, event, unit)
 			end
 		elseif(event == 'NAME_PLATE_UNIT_REMOVED' and unit) then
 			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
@@ -635,7 +635,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			nameplate.unitFrame:UpdateAllElements(event)
 
 			if(nameplateCallback) then
-				nameplateCallback(event, nameplate.unitFrame, unit)
+				nameplateCallback(nameplate.unitFrame, event, unit)
 			end
 		end
 	end)

--- a/ouf.lua
+++ b/ouf.lua
@@ -274,9 +274,11 @@ local function initObject(unit, style, styleFunc, header, ...)
 			func(object)
 		end
 
-		-- Make Clique happy
-		_G.ClickCastFrames = ClickCastFrames or {}
-		ClickCastFrames[object] = true
+		-- Make Clique kinda happy
+		if not object.isNamePlate then
+			_G.ClickCastFrames = ClickCastFrames or {}
+			ClickCastFrames[object] = true
+		end
 	end
 end
 
@@ -611,6 +613,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 			if(not nameplate.unitFrame) then
 				nameplate.unitFrame = CreateFrame('Button', prefix..nameplate:GetName(), nameplate)
 				nameplate.unitFrame:EnableMouse(false)
+				nameplate.unitFrame.isNamePlate = true
 
 				Private.UpdateUnits(nameplate.unitFrame, unit)
 

--- a/ouf.lua
+++ b/ouf.lua
@@ -368,7 +368,7 @@ do
 end
 
 local function generateName(unit, ...)
-	local name = 'oUF_' .. style:gsub('[^%a%d_]+', '')
+	local name = 'oUF_' .. style:gsub('^oUF_?', ''):gsub('[^%a%d_]+', '')
 
 	local raid, party, groupFilter
 	for i = 1, select('#', ...), 2 do

--- a/ouf.lua
+++ b/ouf.lua
@@ -578,11 +578,6 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	-- thus we should allow default nameplate driver to create, update, and remove
 	-- Blizz nameplates. "Disabling" them via oUF:DisableBlizzard is a bit ugly,
 	-- but taint-free solution.
-	NamePlateDriverFrame:Hide()
-	NamePlateDriverFrame:UnregisterAllEvents()
-	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_CREATED')
-	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_ADDED')
-	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_REMOVED')
 	NamePlateDriverFrame:HookScript('OnEvent', function(_, event, unit)
 		if(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
 			self:DisableBlizzard(unit)
@@ -601,16 +596,6 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 					SetCVar(cvar, value)
 				end
 			end
-
-			-- Disable power and classpower bars.
-			ClassNameplateManaBarFrame:UnregisterAllEvents()
-			DeathKnightResourceOverlayFrame:UnregisterAllEvents()
-			ClassNameplateBarMageFrame:UnregisterAllEvents()
-			ClassNameplateBarWindwalkerMonkFrame:UnregisterAllEvents()
-			ClassNameplateBrewmasterBarFrame:UnregisterAllEvents()
-			ClassNameplateBarPaladinFrame:UnregisterAllEvents()
-			ClassNameplateBarRogueDruidFrame:UnregisterAllEvents()
-			ClassNameplateBarWarlockFrame:UnregisterAllEvents()
 		elseif(event == 'PLAYER_TARGET_CHANGED') then
 			local nameplate = C_NamePlate.GetNamePlateForUnit('target')
 			if(not nameplate) then return end

--- a/ouf.lua
+++ b/ouf.lua
@@ -565,6 +565,9 @@ function oUF:Spawn(unit, overrideName)
 end
 
 function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
+	argcheck(nameplateCallback, 3, 'function', 'nil')
+	argcheck(nameplateCVars, 4, 'table', 'nil')
+
 	-- disable blizzard nameplates
 	NamePlateDriverFrame:UnregisterAllEvents()
 	NamePlateDriverFrame:Hide()
@@ -586,7 +589,7 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	eventHandler:RegisterEvent('PLAYER_LOGIN')
 	eventHandler:SetScript('OnEvent', function(_, event, unit)
 		if(event == 'PLAYER_LOGIN') then
-			if(not nameplateCVars or type(nameplateCVars) ~= 'table') then return end
+			if(not nameplateCVars) then return end
 
 			for cvar, value in next, nameplateCVars do
 				SetCVar(cvar, value)

--- a/ouf.lua
+++ b/ouf.lua
@@ -572,24 +572,14 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	local style = style
 	local prefix = namePrefix or generateName()
 
-	local hiddenParent = CreateFrame('Frame', nil, UIParent)
-	hiddenParent:SetAllPoints()
-	hiddenParent:Hide()
-
 	NamePlateDriverFrame:Hide()
 	NamePlateDriverFrame:UnregisterAllEvents()
 	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_CREATED')
 	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_ADDED')
 	NamePlateDriverFrame:RegisterEvent('NAME_PLATE_UNIT_REMOVED')
 	NamePlateDriverFrame:HookScript('OnEvent', function(_, event, unit)
-		if(event == 'NAME_PLATE_UNIT_ADDED') then
-			if(not unit) then return end
-
-			local nameplate = C_NamePlate.GetNamePlateForUnit(unit)
-
-			if(nameplate.UnitFrame) then
-				nameplate.UnitFrame:SetParent(hiddenParent)
-			end
+		if(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
+			self:DisableBlizzard(unit)
 		end
 	end)
 


### PR DESCRIPTION
Rebased commits from #312 onto dev branch. It'll be easier for us to work on it this way.

How-To:
- Register style via [`oUF:RegisterStyle`](https://github.com/oUF-wow/oUF/blob/3a57f683386f6365d3ef55aec1e2c4985233b5ff/ouf.lua#L317);
- Activate style via [`oUF:SetActiveStyle`](https://github.com/oUF-wow/oUF/blob/3a57f683386f6365d3ef55aec1e2c4985233b5ff/ouf.lua#L327);
- Call [`oUF:SpawnNamePlates`](https://github.com/oUF-wow/oUF/blob/3a57f683386f6365d3ef55aec1e2c4985233b5ff/ouf.lua#L569);
- *(In Gordon Ramsay's voice)* Done.

`oUF:SpawnNamePlates` has 3 optional args:
- `namePrefix`. If nil, style's name w/ `oUF_` prefix will be used instead. For example, if `namePrefix` is 'TestPrefix', your nameplates' will have names like 'TestPrefixNamePlate1', 'TestPrefixNamePlate2', etc...;
- `nameplateCallback` is a callback. If callback is called, 3 arguments will be passed: **oUF nameplate** itself, **event**, and **unit**;
- `nameplateCVars` is a list of nameplate CVars that will be applied on `PLAYER_LOGIN`.