### PR TITLE
Power: Check if element is a StatusBar before setting a texture

### DIFF
--- a/elements/power.lua
+++ b/elements/power.lua
@@ -196,24 +196,26 @@ local function Update(self, event, unit)
 
 	t = self.colors.power[ptoken or ptype]
 
-	local atlas = element.atlas or (t and t.atlas)
-	if(element.useAtlas and atlas and displayType ~= ALTERNATE_POWER_INDEX) then
-		element:SetStatusBarAtlas(atlas)
-		element:SetStatusBarColor(1, 1, 1)
+	if(element.isStatusBar) then
+		local atlas = element.atlas or (t and t.atlas)
+		if(element.useAtlas and atlas and displayType ~= ALTERNATE_POWER_INDEX) then
+			element:SetStatusBarAtlas(atlas)
+			element:SetStatusBarColor(1, 1, 1)
 
-		if(element.colorTapping or element.colorDisconnected) then
-			t = disconnected and self.colors.disconnected or self.colors.tapped
-			element:GetStatusBarTexture():SetDesaturated(disconnected or tapped)
-		end
+			if(element.colorTapping or element.colorDisconnected) then
+				t = disconnected and self.colors.disconnected or self.colors.tapped
+				element:GetStatusBarTexture():SetDesaturated(disconnected or tapped)
+			end
 
-		if(t and (r or g or b)) then
-			r, g, b = t[1], t[2], t[3]
-		end
-	else
-		element:SetStatusBarTexture(element.texture)
+			if(t and (r or g or b)) then
+				r, g, b = t[1], t[2], t[3]
+			end
+		else
+			element:SetStatusBarTexture(element.texture)
 
-		if(r or g or b) then
-			element:SetStatusBarColor(r, g, b)
+			if(r or g or b) then
+				element:SetStatusBarColor(r, g, b)
+			end
 		end
 	end
 
@@ -277,6 +279,7 @@ local function Enable(self, unit)
 		if(element:IsObjectType('StatusBar')) then
 			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
 			element:SetStatusBarTexture(element.texture)
+			element.isStatusBar = true
 		end
 
 		return true


### PR DESCRIPTION
So my oUF layout in RealUI uses a non-standard status bar. With the current stable version I am able to use the built in update function to without issue, but when testing on the newer dev version ([patch-classpowers](oUF-wow/oUF#347)), I get this error:
``` lua
115x ...terface\nibRealUI\Libs\oUF\elements\power.lua:213: attempt to call method 'SetStatusBarTexture' (a nil value)
...terface\nibRealUI\Libs\oUF\elements\power.lua:213: in function <...terface\nibRealUI\Libs\oUF\elements\power.lua:125>
(tail call): ?
nibRealUI\Libs\oUF\ouf.lua:200: in function <nibRealUI\Libs\oUF\ouf.lua:189>
(tail call): ?
```
The power element already checks if it's actually a status bar in the `Enable` function, so it seemed inconsistent to **not** also check for that in the `Update` function before trying to apply texture settings to it.

With the power element specifically, I think it's fair to assume that it would have :SetValue, and :SetMinMaxValues, but in order to provide flexibility to the layout I think assuming :SetStatusBarTexture and other texture based methods is a step too far.

One of the greatest features of oUF, to me, is it's resilience when given a widget type it does not expect. I would like to see that carried forward in newer versions.