### PR TITLE
castbar: Add support for reverse fill statusbars

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -141,7 +141,7 @@ local function UNIT_SPELLCAST_START(self, event, unit)
 	local sf = element.SafeZone
 	if(sf) then
 		sf:ClearAllPoints()
-		sf:SetPoint('RIGHT')
+		sf:SetPoint(element:GetReverseFill() and 'LEFT' or 'RIGHT')
 		sf:SetPoint('TOP')
 		sf:SetPoint('BOTTOM')
 		updateSafeZone(element)
@@ -366,7 +366,7 @@ local function UNIT_SPELLCAST_CHANNEL_START(self, event, unit, _, _, _, spellID)
 	local sf = element.SafeZone
 	if(sf) then
 		sf:ClearAllPoints()
-		sf:SetPoint('LEFT')
+		sf:SetPoint(element:GetReverseFill() and 'RIGHT' or 'LEFT')
 		sf:SetPoint('TOP')
 		sf:SetPoint('BOTTOM')
 		updateSafeZone(element)


### PR DESCRIPTION
`statusbar:SetReverseFill(true)` will make the bar fill from right to left, instead of the default left to right. This commit will adjust `SafeZone` to be on the appropriate side if this attribute is set.