### PR TITLE
healthprediction: Element update

### DIFF
--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -9,12 +9,12 @@ HealthPrediction - A `table` containing references to sub-widgets and options.
 
 ## Sub-Widgets
 
-myBar            - A `StatusBar` used to represent incoming heals from the player.
-otherBar         - A `StatusBar` used to represent incoming heals from others.
-damageAbsorbBar  - A `StatusBar` used to represent damage absorbs.
-healAbsorbBar    - A `StatusBar` used to represent heal absorbs.
-overDamageAbsorb - A `Texture` used to signify that the amount of damage absorb is greater than the unit's missing health.
-overHealAbsorb   - A `Texture` used to signify that the amount of heal absorb is greater than the unit's current health.
+myBar          - A `StatusBar` used to represent incoming heals from the player.
+otherBar       - A `StatusBar` used to represent incoming heals from others.
+absorbBar      - A `StatusBar` used to represent damage absorbs.
+healAbsorbBar  - A `StatusBar` used to represent heal absorbs.
+overAbsorb     - A `Texture` used to signify that the amount of damage absorb is greater than the unit's missing health.
+overHealAbsorb - A `Texture` used to signify that the amount of heal absorb is greater than the unit's current health.
 
 ## Notes
 
@@ -43,11 +43,11 @@ A default texture will be applied to the Texture widgets if they don't have a te
     otherBar:SetPoint('LEFT', myBar:GetStatusBarTexture(), 'RIGHT')
     otherBar:SetWidth(200)
 
-    local damageAbsorbBar = CreateFrame('StatusBar', nil, self.Health)
-    damageAbsorbBar:SetPoint('TOP')
-    damageAbsorbBar:SetPoint('BOTTOM')
-    damageAbsorbBar:SetPoint('LEFT', otherBar:GetStatusBarTexture(), 'RIGHT')
-    damageAbsorbBar:SetWidth(200)
+    local absorbBar = CreateFrame('StatusBar', nil, self.Health)
+    absorbBar:SetPoint('TOP')
+    absorbBar:SetPoint('BOTTOM')
+    absorbBar:SetPoint('LEFT', otherBar:GetStatusBarTexture(), 'RIGHT')
+    absorbBar:SetWidth(200)
 
     local healAbsorbBar = CreateFrame('StatusBar', nil, self.Health)
     healAbsorbBar:SetPoint('TOP')
@@ -56,11 +56,11 @@ A default texture will be applied to the Texture widgets if they don't have a te
     healAbsorbBar:SetWidth(200)
     healAbsorbBar:SetReverseFill(true)
 
-    local overDamageAbsorb = self.Health:CreateTexture(nil, "OVERLAY")
-    overDamageAbsorb:SetPoint('TOP')
-    overDamageAbsorb:SetPoint('BOTTOM')
-    overDamageAbsorb:SetPoint('LEFT', self.Health, 'RIGHT')
-    overDamageAbsorb:SetWidth(10)
+    local overAbsorb = self.Health:CreateTexture(nil, "OVERLAY")
+    overAbsorb:SetPoint('TOP')
+    overAbsorb:SetPoint('BOTTOM')
+    overAbsorb:SetPoint('LEFT', self.Health, 'RIGHT')
+    overAbsorb:SetWidth(10)
 
 	local overHealAbsorb = self.Health:CreateTexture(nil, "OVERLAY")
     overHealAbsorb:SetPoint('TOP')
@@ -72,9 +72,9 @@ A default texture will be applied to the Texture widgets if they don't have a te
     self.HealthPrediction = {
         myBar = myBar,
         otherBar = otherBar,
-        damageAbsorbBar = damageAbsorbBar,
+        absorbBar = absorbBar,
         healAbsorbBar = healAbsorbBar,
-        overDamageAbsorb = overDamageAbsorb,
+        overAbsorb = overAbsorb,
         overHealAbsorb = overHealAbsorb,
         maxOverflow = 1.05,
         frequentUpdates = true,
@@ -101,7 +101,7 @@ local function Update(self, event, unit)
 
 	local myIncomingHeal = UnitGetIncomingHeals(unit, 'player') or 0
 	local allIncomingHeal = UnitGetIncomingHeals(unit) or 0
-	local damageAbsorb = UnitGetTotalAbsorbs(unit) or 0
+	local absorb = UnitGetTotalAbsorbs(unit) or 0
 	local healAbsorb = UnitGetTotalHealAbsorbs(unit) or 0
 	local health, maxHealth = UnitHealth(unit), UnitHealthMax(unit)
 
@@ -122,16 +122,16 @@ local function Update(self, event, unit)
 		otherIncomingHeal = allIncomingHeal - myIncomingHeal
 	end
 
-	local hasOverDamageAbsorb = false
-	if(health - healAbsorb + allIncomingHeal + damageAbsorb >= maxHealth or health + damageAbsorb >= maxHealth) then
-		if(damageAbsorb > 0) then
-			hasOverDamageAbsorb = true
+	local hasOverAbsorb = false
+	if(health - healAbsorb + allIncomingHeal + absorb >= maxHealth or health + absorb >= maxHealth) then
+		if(absorb > 0) then
+			hasOverAbsorb = true
 		end
 
 		if(allIncomingHeal > healAbsorb) then
-			damageAbsorb = math.max(0, maxHealth - (health - healAbsorb + allIncomingHeal))
+			absorb = math.max(0, maxHealth - (health - healAbsorb + allIncomingHeal))
 		else
-			damageAbsorb = math.max(0, maxHealth - health)
+			absorb = math.max(0, maxHealth - health)
 		end
 	end
 
@@ -153,10 +153,10 @@ local function Update(self, event, unit)
 		element.otherBar:Show()
 	end
 
-	if(element.damageAbsorbBar) then
-		element.damageAbsorbBar:SetMinMaxValues(0, maxHealth)
-		element.damageAbsorbBar:SetValue(damageAbsorb)
-		element.damageAbsorbBar:Show()
+	if(element.absorbBar) then
+		element.absorbBar:SetMinMaxValues(0, maxHealth)
+		element.absorbBar:SetValue(absorb)
+		element.absorbBar:Show()
 	end
 
 	if(element.healAbsorbBar) then
@@ -165,11 +165,11 @@ local function Update(self, event, unit)
 		element.healAbsorbBar:Show()
 	end
 
-	if(element.overDamageAbsorb) then
-		if(hasOverDamageAbsorb) then
-			element.overDamageAbsorb:Show()
+	if(element.overAbsorb) then
+		if(hasOverAbsorb) then
+			element.overAbsorb:Show()
 		else
-			element.overDamageAbsorb:Hide()
+			element.overAbsorb:Hide()
 		end
 	end
 
@@ -181,20 +181,20 @@ local function Update(self, event, unit)
 		end
 	end
 
-	--[[ Callback: HealthPrediction:PostUpdate(unit, myIncomingHeal, otherIncomingHeal, damageAbsorb, healAbsorb, hasOverDamageAbsorb, hasOverHealAbsorb)
+	--[[ Callback: HealthPrediction:PostUpdate(unit, myIncomingHeal, otherIncomingHeal, absorb, healAbsorb, hasOverAbsorb, hasOverHealAbsorb)
 	Called after the element has been updated.
 
-	* self                - the HealthPrediction element
-	* unit                - the unit for which the update has been triggered (string)
-	* myIncomingHeal      - the amount of incoming healing done by the player (number)
-	* otherIncomingHeal   - the amount of incoming healing done by others (number)
-	* damageAbsorb        - the amount of damage the unit can absorb without losing health (number)
-	* healAbsorb          - the amount of healing the unit can absorb without gaining health (number)
-	* hasOverDamageAbsorb - indicates if the amount of damage absorb is higher than the unit's missing health (boolean)
-	* hasOverHealAbsorb   - indicates if the amount of heal absorb is higher than the unit's current health (boolean)
+	* self              - the HealthPrediction element
+	* unit              - the unit for which the update has been triggered (string)
+	* myIncomingHeal    - the amount of incoming healing done by the player (number)
+	* otherIncomingHeal - the amount of incoming healing done by others (number)
+	* absorb            - the amount of damage the unit can absorb without losing health (number)
+	* healAbsorb        - the amount of healing the unit can absorb without gaining health (number)
+	* hasOverAbsorb     - indicates if the amount of damage absorb is higher than the unit's missing health (boolean)
+	* hasOverHealAbsorb - indicates if the amount of heal absorb is higher than the unit's current health (boolean)
 	--]]
 	if(element.PostUpdate) then
-		return element:PostUpdate(unit, myIncomingHeal, otherIncomingHeal, damageAbsorb, healAbsorb, hasOverDamageAbsorb, hasOverHealAbsorb)
+		return element:PostUpdate(unit, myIncomingHeal, otherIncomingHeal, absorb, healAbsorb, hasOverAbsorb, hasOverHealAbsorb)
 	end
 end
 
@@ -250,12 +250,12 @@ local function Enable(self)
 			element.otherBar:Show()
 		end
 
-		if(element.damageAbsorbBar) then
-			if(element.damageAbsorbBar:IsObjectType('StatusBar') and not element.damageAbsorbBar:GetStatusBarTexture()) then
-				element.damageAbsorbBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
+		if(element.absorbBar) then
+			if(element.absorbBar:IsObjectType('StatusBar') and not element.absorbBar:GetStatusBarTexture()) then
+				element.absorbBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 			end
 
-			element.damageAbsorbBar:Show()
+			element.absorbBar:Show()
 		end
 
 		if(element.healAbsorbBar) then
@@ -266,10 +266,10 @@ local function Enable(self)
 			element.healAbsorbBar:Show()
 		end
 
-		if(element.overDamageAbsorb) then
-			if(element.overDamageAbsorb:IsObjectType('Texture') and not element.overDamageAbsorb:GetTexture()) then
-				element.overDamageAbsorb:SetTexture([[Interface\RaidFrame\Shield-Overshield]])
-				element.overDamageAbsorb:SetBlendMode('ADD')
+		if(element.overAbsorb) then
+			if(element.overAbsorb:IsObjectType('Texture') and not element.overAbsorb:GetTexture()) then
+				element.overAbsorb:SetTexture([[Interface\RaidFrame\Shield-Overshield]])
+				element.overAbsorb:SetBlendMode('ADD')
 			end
 		end
 
@@ -295,16 +295,16 @@ local function Disable(self)
 			element.otherBar:Hide()
 		end
 
-		if(element.damageAbsorbBar) then
-			element.damageAbsorbBar:Hide()
+		if(element.absorbBar) then
+			element.absorbBar:Hide()
 		end
 
 		if(element.healAbsorbBar) then
 			element.healAbsorbBar:Hide()
 		end
 
-		if(element.overDamageAbsorb) then
-			element.overDamageAbsorb:Hide()
+		if(element.overAbsorb) then
+			element.overAbsorb:Hide()
 		end
 
 		if(element.overHealAbsorb) then

--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -84,19 +84,20 @@ A default texture will be applied to the Texture widgets if they don't have a te
 local _, ns = ...
 local oUF = ns.oUF
 
-local math_max = math.max
-
 local function Update(self, event, unit)
 	if(self.unit ~= unit) then return end
 
 	local element = self.HealthPrediction
+
 	--[[ Callback: HealthPrediction:PreUpdate(unit)
 	Called before the element has been updated.
 
 	* self - the HealthPrediction element
 	* unit - the unit for which the update has been triggered (string)
 	--]]
-	if(element.PreUpdate) then element:PreUpdate(unit) end
+	if(element.PreUpdate) then
+		element:PreUpdate(unit)
+	end
 
 	local myIncomingHeal = UnitGetIncomingHeals(unit, 'player') or 0
 	local allIncomingHeal = UnitGetIncomingHeals(unit) or 0
@@ -128,9 +129,9 @@ local function Update(self, event, unit)
 		end
 
 		if(allIncomingHeal > healAbsorb) then
-			damageAbsorb = math_max(0, maxHealth - (health - healAbsorb + allIncomingHeal))
+			damageAbsorb = math.max(0, maxHealth - (health - healAbsorb + allIncomingHeal))
 		else
-			damageAbsorb = math_max(0, maxHealth - health)
+			damageAbsorb = math.max(0, maxHealth - health)
 		end
 	end
 
@@ -218,14 +219,14 @@ local function Enable(self)
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
 
-		self:RegisterEvent('UNIT_HEAL_PREDICTION', Path)
-		self:RegisterEvent('UNIT_MAXHEALTH', Path)
-
 		if(element.frequentUpdates) then
 			self:RegisterEvent('UNIT_HEALTH_FREQUENT', Path)
 		else
 			self:RegisterEvent('UNIT_HEALTH', Path)
 		end
+
+		self:RegisterEvent('UNIT_MAXHEALTH', Path)
+		self:RegisterEvent('UNIT_HEAL_PREDICTION', Path)
 		self:RegisterEvent('UNIT_ABSORB_AMOUNT_CHANGED', Path)
 		self:RegisterEvent('UNIT_HEAL_ABSORB_AMOUNT_CHANGED', Path)
 
@@ -240,6 +241,7 @@ local function Enable(self)
 
 			element.myBar:Show()
 		end
+
 		if(element.otherBar) then
 			if(element.otherBar:IsObjectType('StatusBar') and not element.otherBar:GetStatusBarTexture()) then
 				element.otherBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
@@ -247,6 +249,7 @@ local function Enable(self)
 
 			element.otherBar:Show()
 		end
+
 		if(element.damageAbsorbBar) then
 			if(element.damageAbsorbBar:IsObjectType('StatusBar') and not element.damageAbsorbBar:GetStatusBarTexture()) then
 				element.damageAbsorbBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
@@ -254,6 +257,7 @@ local function Enable(self)
 
 			element.damageAbsorbBar:Show()
 		end
+
 		if(element.healAbsorbBar) then
 			if(element.healAbsorbBar:IsObjectType('StatusBar') and not element.healAbsorbBar:GetStatusBarTexture()) then
 				element.healAbsorbBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
@@ -261,12 +265,14 @@ local function Enable(self)
 
 			element.healAbsorbBar:Show()
 		end
+
 		if(element.overDamageAbsorb) then
 			if(element.overDamageAbsorb:IsObjectType('Texture') and not element.overDamageAbsorb:GetTexture()) then
 				element.overDamageAbsorb:SetTexture([[Interface\RaidFrame\Shield-Overshield]])
 				element.overDamageAbsorb:SetBlendMode('ADD')
 			end
 		end
+
 		if(element.overHealAbsorb) then
 			if(element.overHealAbsorb:IsObjectType('Texture') and not element.overHealAbsorb:GetTexture()) then
 				element.overHealAbsorb:SetTexture([[Interface\RaidFrame\Absorb-Overabsorb]])
@@ -284,26 +290,31 @@ local function Disable(self)
 		if(element.myBar) then
 			element.myBar:Hide()
 		end
+
 		if(element.otherBar) then
 			element.otherBar:Hide()
 		end
+
 		if(element.damageAbsorbBar) then
 			element.damageAbsorbBar:Hide()
 		end
+
 		if(element.healAbsorbBar) then
 			element.healAbsorbBar:Hide()
 		end
+
 		if(element.overDamageAbsorb) then
 			element.overDamageAbsorb:Hide()
 		end
+
 		if(element.overHealAbsorb) then
 			element.overHealAbsorb:Hide()
 		end
 
-		self:UnregisterEvent('UNIT_HEAL_PREDICTION', Path)
-		self:UnregisterEvent('UNIT_MAXHEALTH', Path)
 		self:UnregisterEvent('UNIT_HEALTH', Path)
+		self:UnregisterEvent('UNIT_MAXHEALTH', Path)
 		self:UnregisterEvent('UNIT_HEALTH_FREQUENT', Path)
+		self:UnregisterEvent('UNIT_HEAL_PREDICTION', Path)
 		self:UnregisterEvent('UNIT_ABSORB_AMOUNT_CHANGED', Path)
 		self:UnregisterEvent('UNIT_HEAL_ABSORB_AMOUNT_CHANGED', Path)
 	end

--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -185,8 +185,8 @@ local function Update(self, event, unit)
 
 	* self                - the HealthPrediction element
 	* unit                - the unit for which the update has been triggered (string)
-	* myIncomingHeal      - the amount of incoming heal done by the player (number)
-	* otherIncomingHeal   - the amount of incoming heal from other sources (number)
+	* myIncomingHeal      - the amount of incoming healing done by the player (number)
+	* otherIncomingHeal   - the amount of incoming healing done by others (number)
 	* damageAbsorb        - the amount of damage the unit can absorb without losing health (number)
 	* healAbsorb          - the amount of healing the unit can absorb without gaining health (number)
 	* hasOverDamageAbsorb - indicates if the amount of damage absorb is higher than the unit's missing health (boolean)


### PR DESCRIPTION
Changes:
* ~~Renamed `absorbBar` and  `overAbsorb` sub-widgets to `damageAbsorbBar` and `overDamageAbsorb`. This will make their purpose more clear to newer users, will improve readability, and, lastly, their heal absorbing counterparts have "heal" in their names;~~

* Changed list of arguments that's passed to `PostUpdate` func. New arguments are `myIncomingHeal`, `otherIncomingHeal`, `damageAbsorb`, `healAbsorb`, `hasOverDamageAbsorb`, `hasOverHealAbsorb`. Basically, these are `cur` values of all status bars + 2 extras, for some reason we weren't passing the most important stuff, why?;

* Removed useless `overHealAmount` variable/arg, it's calculated for the sake of being passed to `PostUpdate`.