### PR TITLE
classpower: Only show active bars

### DIFF
--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -113,10 +113,17 @@ local function Update(self, event, unit, powerType)
 			mod = UnitPowerDisplayMod(ClassPowerID)
 		end
 
+		local numActive = math.ceil(mod == 0 and 0 or cur / mod)
 		for i = 1, max do
-			element[i]:Show()
-			-- mod should never be 0, but according to Blizz code it can actually happen
-			element[i]:SetValue(mod == 0 and 0 or (cur / mod - i + 1))
+			local bar = element[i]
+			if(i > numActive) then
+				bar:Hide()
+				bar:SetValue(0)
+			else
+				bar:Show()
+				-- mod should never be 0, but according to Blizz code it can actually happen
+				bar:SetValue(mod == 0 and 0 or (cur / mod - i + 1))
+			end
 		end
 
 		oldMax = element.__max

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -115,14 +115,13 @@ local function Update(self, event, unit, powerType)
 
 		local numActive = math.ceil(mod == 0 and 0 or cur / mod)
 		for i = 1, max do
-			local bar = element[i]
 			if(i > numActive) then
-				bar:Hide()
-				bar:SetValue(0)
+				element[i]:Hide()
+				element[i]:SetValue(0)
 			else
-				bar:Show()
+				element[i]:Show()
 				-- mod should never be 0, but according to Blizz code it can actually happen
-				bar:SetValue(mod == 0 and 0 or (cur / mod - i + 1))
+				element[i]:SetValue(mod == 0 and 0 or (cur / mod - i + 1))
 			end
 		end
 

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -113,7 +113,7 @@ local function Update(self, event, unit, powerType)
 			mod = UnitPowerDisplayMod(ClassPowerID)
 		end
 
-		local numActive = math.ceil(mod == 0 and 0 or cur / mod)
+		local numActive = (mod == 0 and 0 or cur / mod) + 0.9
 		for i = 1, max do
 			if(i > numActive) then
 				element[i]:Hide()


### PR DESCRIPTION
Currently, all bars are shown regardless of current power, and instead fills when the power is available.
This means with e.g. 0 combo points it shows 5 empty bars.

With this patch it shows only those who're (partially) filled.