### PR TITLE
classpower: Element update

### DIFF
--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -119,7 +119,7 @@ local function Update(self, event, unit, powerType)
 
 		-- BUG: Destruction is supposed to show partial soulshards, but Affliction and Demonology should only show full ones
 		if(ClassPowerType == 'SOUL_SHARDS' and GetSpecialization() ~= SPEC_WARLOCK_DESTRUCTION) then
-			cur = math.floor(cur)
+			cur = cur - cur % 1
 		end
 
 		local numActive = cur + 0.9


### PR DESCRIPTION
Added non-destro soul shards bugfix;
Removed `mod` arg, it's not really needed.

If someone for some reason needs a number of fragments, one can do `local frags = cur % 1` instead of `local frags = cur % mod`.