### PR TITLE
Feature: Arena Preperation (take two!)

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -2,10 +2,58 @@ local parent, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
+local function updateElement(self, event, element, specID)
+	local el = self[element]
+	if(el and self:IsElementEnabled(element)) then
+		el:SetMinMaxValues(0, 1)
+		el:SetValue(1)
+
+		local r, g, b, t, _
+		if(el.colorPower and element == 'Power') then
+			-- FIXME: no idea if we can get power type here without the unit
+		elseif(el.colorClass) then
+			local _, _, _, _, _, _, class = GetSpecializationInfoByID(specID)
+			t = self.colors.class[class]
+		elseif(el.colorReaction) then
+			t = self.colors.reaction[2]
+		elseif(el.colorSmooth) then
+			_, _, _, _, _, _, r, g, b = unpack(el.smoothGradient or self.colors.smooth)
+		elseif(el.colorHealth and element == 'Health') then
+			t = self.colors.health
+		end
+
+		if(t) then
+			r, g, b = t[1], t[2], t[3]
+		end
+
+		if(r or g or b) then
+			el:SetStatusBarColor(r, g, b)
+
+			local bg = el.bg
+			if(bg) then
+				local mu = bg.multiplier or 1
+				bg:SetVertexColor(r * mu, g * mu, b * mu)
+			end
+		end
+	end
+end
+
 function Private.UpdateArenaPreperation(self, event)
 	if(event == 'ARENA_OPPONENT_UPDATE' and not self:IsEnabled()) then
 		self:Enable()
+		self:UpdateAllElements('ArenaPreparation')
 		self:UnregisterEvent(event, Private.UpdateArenaPreperation)
+
+		-- show elements that don't handle their own visibility
+		if(self:IsElementEnabled('Auras')) then
+			if(self.Auras) then self.Auras:Show() end
+			if(self.Buffs) then self.Buffs:Show() end
+			if(self.Debuffs) then self.Debuffs:Show() end
+		end
+
+		if(self.Portrait and self:IsElementEnabled('Portrait')) then
+			self.Portrait:Show()
+		end
 	elseif(event == 'PLAYER_ENTERING_WORLD' and not UnitExists(self.unit)) then
 		Private.UpdateArenaPreperation(self, 'ARENA_PREP_OPPONENT_SPECIALIZATIONS')
 	elseif(event == 'ARENA_PREP_OPPONENT_SPECIALIZATIONS') then
@@ -16,7 +64,23 @@ function Private.UpdateArenaPreperation(self, event)
 				self:RegisterEvent('ARENA_OPPONENT_UPDATE', Private.UpdateArenaPreperation)
 			end
 
+			-- pseudo-element updates
+			updateElement(self, event, 'Health', specID)
+			updateElement(self, event, 'Power', specID)
+
+			-- hide all other (relevant) elements
+			if(self.Auras) then self.Auras:Hide() end
+			if(self.Buffs) then self.Buffs:Hide() end
+			if(self.Debuffs) then self.Debuffs:Hide() end
+			if(self.Castbar) then self.Castbar:Hide() end
+			if(self.CombatIndicator) then self.CombatIndicator:Hide() end
+			if(self.GroupRoleIndicator) then self.GroupRoleIndicator:Hide() end
+			if(self.Portrait) then self.Portrait:Hide() end
+			if(self.PvPIndicator) then self.PvPIndicator:Hide() end
+			if(self.RaidTargetIndicator) then self.RaidTargetIndicator:Hide() end
+
 			self:Show()
+			self:ForceUpdateTags()
 		end
 	end
 end

--- a/arena.lua
+++ b/arena.lua
@@ -6,6 +6,23 @@ local function updateElement(self, event, element, specID)
 	local el = self[element]
 	if(el and self:IsElementEnabled(element)) then
 		if(el.Override) then
+			--[[ Override: Health.OverrideArenaPreparation(self, event, specID)
+			Used as an alternative to Health.Override for arena preperation frames.
+
+			* self   - the parent object
+			* event  - the event triggering the update (string)
+			* specID - the specialization ID for the opponent (number)
+			--]]
+			--[[ Override: Power.OverrideArenaPreparation(self, event, specID)
+			Used as an alternative to Power.Override for arena preperation frames.
+
+			* self   - the parent object
+			* event  - the event triggering the update (string)
+			* specID - the specialization ID for the opponent (number)
+			--]]
+			if(el.OverrideArenaPreparation) then
+				el.OverrideArenaPreparation(self, event, specID)
+			end
 			return
 		end
 
@@ -38,6 +55,23 @@ local function updateElement(self, event, element, specID)
 				local mu = bg.multiplier or 1
 				bg:SetVertexColor(r * mu, g * mu, b * mu)
 			end
+		end
+
+		--[[ Callback: Health:PostUpdateArenaPreparation(specID)
+		Called after the element has been updated during arena preperation.
+
+		* self   - the Health element
+		* specID - the specialization ID for the opponent (number)
+		--]]
+		--[[ Callback: Power:PostUpdateArenaPreparation(specID)
+		Called after the element has been updated during arena preperation.
+
+		* self   - the Power element
+		* specID - the specialization ID for the opponent (number)
+		--]]
+		if(el.PostUpdateArenaPreparation) then
+			-- TODO: document
+			el:PostUpdateArenaPreparation(specID)
 		end
 	end
 end

--- a/arena.lua
+++ b/arena.lua
@@ -1,0 +1,22 @@
+local parent, ns = ...
+local oUF = ns.oUF
+local Private = oUF.Private
+
+function Private.UpdateArenaPreperation(self, event)
+	if(event == 'ARENA_OPPONENT_UPDATE' and not self:IsEnabled()) then
+		self:Enable()
+		self:UnregisterEvent(event, Private.UpdateArenaPreperation)
+	elseif(event == 'PLAYER_ENTERING_WORLD' and not UnitExists(self.unit)) then
+		Private.UpdateArenaPreperation(self, 'ARENA_PREP_OPPONENT_SPECIALIZATIONS')
+	elseif(event == 'ARENA_PREP_OPPONENT_SPECIALIZATIONS') then
+		local specID = GetArenaOpponentSpec(tonumber(id))
+		if(specID) then
+			if(self:IsEnabled()) then
+				self:Disable()
+				self:RegisterEvent('ARENA_OPPONENT_UPDATE', Private.UpdateArenaPreperation)
+			end
+
+			self:Show()
+		end
+	end
+end

--- a/arena.lua
+++ b/arena.lua
@@ -57,7 +57,13 @@ function Private.UpdateArenaPreperation(self, event)
 	elseif(event == 'PLAYER_ENTERING_WORLD' and not UnitExists(self.unit)) then
 		Private.UpdateArenaPreperation(self, 'ARENA_PREP_OPPONENT_SPECIALIZATIONS')
 	elseif(event == 'ARENA_PREP_OPPONENT_SPECIALIZATIONS') then
-		local specID = GetArenaOpponentSpec(tonumber(id))
+		local id = tonumber(self.id)
+		if(not self:IsEnabled() and GetNumArenaOpponentSpecs() < id) then
+			-- in case someone leaves
+			self:Hide()
+		end
+
+		local specID = GetArenaOpponentSpec(id)
 		if(specID) then
 			if(self:IsEnabled()) then
 				self:Disable()

--- a/arena.lua
+++ b/arena.lua
@@ -5,6 +5,10 @@ local Private = oUF.Private
 local function updateElement(self, event, element, specID)
 	local el = self[element]
 	if(el and self:IsElementEnabled(element)) then
+		if(el.Override) then
+			return
+		end
+
 		el:SetMinMaxValues(0, 1)
 		el:SetValue(1)
 

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -406,6 +406,17 @@ local tagStrings = {
 
 		return Hex(t)
 	end]],
+
+	['arenaspec'] = [[function(u)
+		local id = u:match('arena(%d)$')
+		if(id) then
+			local specID = GetArenaOpponentSpec(tonumber(id))
+			if(specID and specID > 0) then
+				local _, specName = GetSpecializationInfoByID(specID)
+				return specName
+			end
+		end
+	end]],
 }
 
 local tags = setmetatable(
@@ -488,6 +499,7 @@ local tagEvents = {
 	['chi']                 = 'UNIT_POWER SPELLS_CHANGED',
 	['arcanecharges']       = 'UNIT_POWER SPELLS_CHANGED',
 	['powercolor']          = 'UNIT_DISPLAYPOWER',
+	['arenaspec']           = 'ARENA_PREP_OPPONENT_SPECIALIZATIONS',
 }
 
 local unitlessEvents = {
@@ -496,6 +508,7 @@ local unitlessEvents = {
 	PLAYER_TARGET_CHANGED = true,
 	PARTY_LEADER_CHANGED = true,
 	GROUP_ROSTER_UPDATE = true,
+	ARENA_PREP_OPPONENT_SPECIALIZATIONS = true,
 }
 
 local events = {}

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -186,9 +186,18 @@ local tagStrings = {
 	end]],
 
 	['raidcolor'] = [[function(u)
-		local _, x = UnitClass(u)
-		if(x) then
-			return Hex(_COLORS.class[x])
+		local _, class = UnitClass(u)
+		if(class) then
+			return Hex(_COLORS.class[class])
+		else
+			local id = u:match('arena(%d)$')
+			if(id) then
+				local specID = GetArenaOpponentSpec(tonumber(id))
+				if(specID and specID > 0) then
+					_, _, _, _, _, class = GetSpecializationInfoByID(specID)
+					return Hex(_COLORS.class[class])
+				end
+			end
 		end
 	end]],
 

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -531,7 +531,12 @@ local function createOnUpdate(timer)
 	end
 end
 
-local function onShow(self)
+--[[ Tags: frame:ForceUpdateTags()
+Used to forcefully update all tags on a frame.
+
+* self - the unit frame from which to update the tags
+--]]
+local function ForceUpdate(self)
 	for _, fs in next, self.__tags do
 		fs:UpdateTag()
 	end
@@ -594,7 +599,7 @@ local function Tag(self, fs, tagstr)
 
 	if(not self.__tags) then
 		self.__tags = {}
-		table.insert(self.__elements, onShow)
+		table.insert(self.__elements, ForceUpdate)
 	else
 		-- Since people ignore everything that's good practice - unregister the tag
 		-- if it already exists.
@@ -790,3 +795,4 @@ oUF.Tags = {
 
 oUF:RegisterMetaFunction('Tag', Tag)
 oUF:RegisterMetaFunction('Untag', Untag)
+oUF:RegisterMetaFunction('ForceUpdateTags', ForceUpdate)

--- a/oUF.xml
+++ b/oUF.xml
@@ -5,6 +5,7 @@
 	<Script file="events.lua"/>
 	<Script file="factory.lua"/>
 	<Script file="blizzard.lua"/>
+	<Script file="arena.lua"/>
 	<Script file="units.lua"/>
 	<Script file="colors.lua"/>
 	<Script file="finalize.lua"/>

--- a/ouf.lua
+++ b/ouf.lua
@@ -161,6 +161,14 @@ for k, v in next, {
 		return active and active[name]
 	end,
 
+	--[[ frame:IsEnabled()
+
+	Used to check if the given frame is enabled or not. This is a reference to `UnitWatchRegistered`.
+
+	* self - unit frame
+	--]]
+	IsEnabled = UnitWatchRegistered,
+
 	--[[ frame:Enable(asState)
 	Used to toggle the visibility of a unit frame based on the existence of its unit. This is a reference to
 	`RegisterUnitWatch`.

--- a/ouf.lua
+++ b/ouf.lua
@@ -290,6 +290,13 @@ local function initObject(unit, style, styleFunc, header, ...)
 			else
 				oUF:HandleUnit(object)
 			end
+
+			-- Arena preparation
+			if(unit and unit:match('arena%d?$')) then
+				object:RegisterEvent('ARENA_PREP_OPPONENT_SPECIALIZATIONS', Private.UpdateArenaPreperation, true)
+				-- the event handler only fires for visible frames, so we have to hook it
+				object:HookScript('OnEvent', Private.UpdateArenaPreperation)
+			end
 		else
 			-- Used to update frames when they change position in a group.
 			object:RegisterEvent('GROUP_ROSTER_UPDATE', object.UpdateAllElements)


### PR DESCRIPTION
This PR supersedes #275 and resolves #177.

By taking over the `arena#` frames' state driver until the unitIDs become available, this PR achieves the following:
- Displays the arena frames with bogus health/power information during arena preperation
    - Has callbacks/overrides and respects `.Override`
- Hides all other (relevant) elements
- Adds Class color support in `[raidcolor]` tag
- Adds new tag `[arenaspec]` which also work on the normal `arena#` frames
- Added `ForceUpdateTags` method (basically exposing an existing function)
- Added `frame:IsEnabled()` shorthand for UnitWatchRegistered

That should cover most of the available features with the arena prep system, and it requires no additional setup for the layout (plug-n-play).

One thing to note, the event `ARENA_PREP_OPPONENT_SPECIALIZATIONS` doesn't seem to fire until a teammate is in the arena with you. I've notified Blizzard about this, as the issue was introduced with 7.0.

Please test!