### PR TITLE
castbar: fix SafeZone width calculation

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -91,7 +91,7 @@ local function updateSafeZone(self)
 	-- Guard against GetNetStats returning latencies of 0.
 	if(ms ~= 0) then
 		-- MADNESS!
-		local safeZonePercent = (width / self.max) * (ms / 1e5)
+		local safeZonePercent = (ms / 1e3) / self.max
 		if(safeZonePercent > 1) then
 			safeZonePercent = 1
 		end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -94,7 +94,6 @@ local function updateSafeZone(self)
 	end
 
 	safeZone:SetWidth(width * safeZoneRatio)
-	safeZone:Show()
 end
 
 local function UNIT_SPELLCAST_START(self, event, unit)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -88,19 +88,13 @@ local function updateSafeZone(self)
 	local width = self:GetWidth()
 	local _, _, _, ms = GetNetStats()
 
-	-- Guard against GetNetStats returning latencies of 0.
-	if(ms ~= 0) then
-		-- MADNESS!
-		local safeZonePercent = (ms / 1e3) / self.max
-		if(safeZonePercent > 1) then
-			safeZonePercent = 1
-		end
-
-		safeZone:SetWidth(width * safeZonePercent)
-		safeZone:Show()
-	else
-		safeZone:Hide()
+	local safeZoneRatio = (ms / 1e3) / self.max
+	if(safeZoneRatio > 1) then
+		safeZoneRatio = 1
 	end
+
+	safeZone:SetWidth(width * safeZoneRatio)
+	safeZone:Show()
 end
 
 local function UNIT_SPELLCAST_START(self, event, unit)


### PR DESCRIPTION
safeZonePercent is already multiplied by width below in SetWidth.
self.max is in seconds, and ms is in milliseconds - hence 1e5 is too big.

(safeZonePercent is actually a ratio, but that's not renamed here)