### PR TITLE
core: Let the packager set a static version

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -1,6 +1,6 @@
 local parent, ns = ...
 local global = GetAddOnMetadata(parent, 'X-oUF')
-local _VERSION = GetAddOnMetadata(parent, 'version')
+local _VERSION = '@project-version@'
 if(_VERSION:find('project%-version')) then
 	_VERSION = 'devel'
 end


### PR DESCRIPTION
Old method breaks with embedded instances of oUF.