### PR TITLE
core: set the `toggleForVehicle` attribute to false

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -274,7 +274,8 @@ local function initObject(unit, style, styleFunc, header, ...)
 
 			-- No need to enable this for *target frames.
 			if(not (unit:match('target') or suffix == 'target')) then
-				object:SetAttribute('toggleForVehicle', true)
+				-- BUG: Blizzard has changed the way vehicles work for Antoran High Command
+				object:SetAttribute('toggleForVehicle', false)
 			end
 
 			-- Other boss and target units are handled by :HandleUnit().
@@ -550,7 +551,8 @@ do
 
 				frame:SetAttribute('*type1', 'target')
 				frame:SetAttribute('*type2', 'togglemenu')
-				frame:SetAttribute('toggleForVehicle', true)
+				-- BUG: Blizzard has changed the way vehicles work for Antoran High Command
+				frame:SetAttribute('toggleForVehicle', false)
 				frame:SetAttribute('oUF-guessUnit', unit)
 			end
 


### PR DESCRIPTION
Blizzard has changed the way vehicles work for Antoran High Command (see #402)
This way vehicles are still targetable through the corresponding pet buttons (see http://wowwiki.wikia.com/wiki/SecureActionButtonTemplate#Other_attributes)