### PR TITLE
core: Disable raid frames vehicle handling in Antorus raid

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -508,7 +508,7 @@ do
 	end
 
 	-- There has to be an easier way to do this.
-	local initialConfigFunction = [[
+	local initialConfigFunctionTemp = [[
 		local header = self:GetParent()
 		local frames = table.new()
 		table.insert(frames, self)
@@ -550,7 +550,7 @@ do
 
 				frame:SetAttribute('*type1', 'target')
 				frame:SetAttribute('*type2', 'togglemenu')
-				frame:SetAttribute('toggleForVehicle', true)
+				frame:SetAttribute('toggleForVehicle', %d == 1)
 				frame:SetAttribute('oUF-guessUnit', unit)
 			end
 
@@ -568,6 +568,9 @@ do
 			clique:RunAttribute('clickcast_register')
 		end
 	]]
+
+	-- it's needed for vehicle hack
+	local initialConfigFunction = initialConfigFunctionTemp:format(1)
 
 	--[[ oUF:SpawnHeader(overrideName, template, visibility, ...)
 	Used to create a group header and apply the currently active style to it.
@@ -647,14 +650,24 @@ do
 	eventHandler:RegisterEvent('ZONE_CHANGED_NEW_AREA')
 	eventHandler:RegisterEvent('PLAYER_REGEN_ENABLED')
 	eventHandler:SetScript('OnEvent', function(_, event)
-		if(event == 'PLAYER_LOGIN' or event == 'ZONE_CHANGED_NEW_AREA') then
+		if(event == 'PLAYER_LOGIN') then
+			if(IsInInstance()) then
+				local _, _, _, _, _, _, _, id = GetInstanceInfo()
+
+				if(id == 1712) then
+					initialConfigFunction = initialConfigFunctionTemp:format(0)
+				end
+			end
+		elseif(event == 'ZONE_CHANGED_NEW_AREA') then
 			local id, _
 			if(IsInInstance()) then
 				_, _, _, _, _, _, _, id = GetInstanceInfo()
 			end
 
-			if(id and id == 1712) then
+			if(id == 1712) then
 				if(not isHacked) then
+					initialConfigFunction = initialConfigFunctionTemp:format(0)
+
 					if(not InCombatLockdown()) then
 						for _, header in next, headers do
 							for _, button in next, {header:GetChildren()} do
@@ -670,6 +683,8 @@ do
 				end
 			else
 				if(isHacked) then
+					initialConfigFunction = initialConfigFunctionTemp:format(1)
+
 					if(not InCombatLockdown()) then
 						for _, header in next, headers do
 							for _, button in next, {header:GetChildren()} do

--- a/ouf.lua
+++ b/ouf.lua
@@ -659,6 +659,9 @@ do
 				child:SetAttribute('toggleForVehicle', flag)
 			end
 		end
+
+		isHacked = not flag
+		shouldHack = nil
 	end
 
 	local eventHandler = CreateFrame('Frame')
@@ -673,7 +676,6 @@ do
 
 				-- This is here for layouts that don't use oUF:Factory
 				toggleHeaders(false)
-				isHacked = true
 			end
 		elseif(event == 'ZONE_CHANGED_NEW_AREA') then
 			local _, _, _, _, _, _, _, id = GetInstanceInfo()
@@ -682,8 +684,6 @@ do
 
 				if(not InCombatLockdown()) then
 					toggleHeaders(false)
-					isHacked = true
-					shouldHack = nil
 				else
 					shouldHack = true
 				end
@@ -692,21 +692,15 @@ do
 
 				if(not InCombatLockdown()) then
 					toggleHeaders(true)
-					isHacked = false
-					shouldHack = nil
 				else
 					shouldHack = false
 				end
 			end
 		elseif(event == 'PLAYER_REGEN_ENABLED') then
-			if(isHacked and not shouldHack == false) then
+			if(isHacked and shouldHack == false) then
 				toggleHeaders(true)
-				isHacked = false
-				shouldHack = nil
 			elseif(not isHacked and shouldHack) then
 				toggleHeaders(false)
-				isHacked = true
-				shouldHack = nil
 			end
 		end
 	end)

--- a/ouf.lua
+++ b/ouf.lua
@@ -637,6 +637,75 @@ do
 
 		return header
 	end
+
+	-- hacks
+	local isHacked = false
+	local shouldHack
+
+	local eventHandler = CreateFrame('Frame')
+	eventHandler:RegisterEvent('PLAYER_LOGIN')
+	eventHandler:RegisterEvent('ZONE_CHANGED_NEW_AREA')
+	eventHandler:RegisterEvent('PLAYER_REGEN_ENABLED')
+	eventHandler:SetScript('OnEvent', function(_, event)
+		if(event == 'PLAYER_LOGIN' or event == 'ZONE_CHANGED_NEW_AREA') then
+			local id, _
+			if(IsInInstance()) then
+				_, _, _, _, _, _, _, id = GetInstanceInfo()
+			end
+
+			if(id and id == 1712) then
+				if(not isHacked) then
+					if(not InCombatLockdown()) then
+						for _, header in next, headers do
+							for _, button in next, {header:GetChildren()} do
+								button:SetAttribute('toggleForVehicle', false)
+							end
+						end
+
+						isHacked = true
+						shouldHack = nil
+					else
+						shouldHack = true
+					end
+				end
+			else
+				if(isHacked) then
+					if(not InCombatLockdown()) then
+						for _, header in next, headers do
+							for _, button in next, {header:GetChildren()} do
+								button:SetAttribute('toggleForVehicle', true)
+							end
+						end
+
+						isHacked = false
+						shouldHack = nil
+					else
+						shouldHack = false
+					end
+				end
+			end
+		elseif(event == 'PLAYER_REGEN_ENABLED') then
+			if(isHacked and shouldHack == false) then
+				for _, header in next, headers do
+					for _, button in next, {header:GetChildren()} do
+						button:SetAttribute('toggleForVehicle', true)
+					end
+				end
+
+				isHacked = false
+				shouldHack = nil
+			elseif(not isHacked and shouldHack == true) then
+				for _, header in next, headers do
+					for _, button in next, {header:GetChildren()} do
+						button:SetAttribute('toggleForVehicle', false)
+					end
+				end
+
+				isHacked = true
+				shouldHack = nil
+			end
+		end
+	end)
 end
 
 --[[ oUF:Spawn(unit, overrideName)

--- a/ouf.lua
+++ b/ouf.lua
@@ -656,6 +656,8 @@ do
 
 				if(id == 1712) then
 					initialConfigFunction = initialConfigFunctionTemp:format(0)
+
+					isHacked = true
 				end
 			end
 		elseif(event == 'ZONE_CHANGED_NEW_AREA') then

--- a/ouf.lua
+++ b/ouf.lua
@@ -672,6 +672,8 @@ do
 
 					if(not InCombatLockdown()) then
 						for _, header in next, headers do
+							header:SetAttribute('initialConfigFunction', initialConfigFunction)
+
 							for _, button in next, {header:GetChildren()} do
 								button:SetAttribute('toggleForVehicle', false)
 							end
@@ -689,6 +691,8 @@ do
 
 					if(not InCombatLockdown()) then
 						for _, header in next, headers do
+							header:SetAttribute('initialConfigFunction', initialConfigFunction)
+
 							for _, button in next, {header:GetChildren()} do
 								button:SetAttribute('toggleForVehicle', true)
 							end
@@ -704,6 +708,8 @@ do
 		elseif(event == 'PLAYER_REGEN_ENABLED') then
 			if(isHacked and shouldHack == false) then
 				for _, header in next, headers do
+					header:SetAttribute('initialConfigFunction', initialConfigFunction)
+
 					for _, button in next, {header:GetChildren()} do
 						button:SetAttribute('toggleForVehicle', true)
 					end
@@ -713,6 +719,8 @@ do
 				shouldHack = nil
 			elseif(not isHacked and shouldHack == true) then
 				for _, header in next, headers do
+					header:SetAttribute('initialConfigFunction', initialConfigFunction)
+
 					for _, button in next, {header:GetChildren()} do
 						button:SetAttribute('toggleForVehicle', false)
 					end

--- a/ouf.lua
+++ b/ouf.lua
@@ -274,7 +274,12 @@ local function initObject(unit, style, styleFunc, header, ...)
 
 			-- No need to enable this for *target frames.
 			if(not (unit:match('target') or suffix == 'target')) then
-				object:SetAttribute('toggleForVehicle', true)
+				if(unit:match('raid') or unit:match('party')) then
+					-- See issue #404
+					object:SetAttribute('toggleForVehicle', false)
+				else
+					object:SetAttribute('toggleForVehicle', true)
+				end
 			end
 
 			-- Other boss and target units are handled by :HandleUnit().

--- a/ouf.lua
+++ b/ouf.lua
@@ -657,6 +657,15 @@ do
 				if(id == 1712) then
 					initialConfigFunction = initialConfigFunctionTemp:format(0)
 
+					-- This is here for layouts that don't use oUF:Factory
+					for _, header in next, headers do
+						header:SetAttribute('initialConfigFunction', initialConfigFunction)
+
+						for _, button in next, {header:GetChildren()} do
+							button:SetAttribute('toggleForVehicle', false)
+						end
+					end
+
 					isHacked = true
 				end
 			end


### PR DESCRIPTION
It's WIP fix for #402, unlike #403 it doesn't break raid vehicle frames in other raids like Ulduar or EoE.

Logic is quite straightforward. When you zone into Antorus, it'll hack raid frames, but when you zone out it'll unhack them. If you're in combat, this un/hackery will be delayed :grin::gun:

@pquerner, @Blazeflack, @Grimsbain test it, pls 😭 

Suggestions are also welcome...