### PR TITLE
[healthprediction] Update maths [WIP]

### DIFF
--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -137,7 +137,7 @@ local function Update(self, event, unit)
 			hasOverAbsorb = true
 		end
 
-		absorb = math.max(0, maxHealth - (health + allIncomingHeal))
+		absorb = math.max(0, maxHealth - health - allIncomingHeal)
 	end
 
 	if(element.myBar) then

--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -132,7 +132,7 @@ local function Update(self, event, unit)
 	end
 
 	local hasOverAbsorb = false
-	if(health + allIncomingHeal + absorb >= maxHealth or health + absorb >= maxHealth) then
+	if(health + allIncomingHeal + absorb >= maxHealth) then
 		if(absorb > 0) then
 			hasOverAbsorb = true
 		end

--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -104,47 +104,40 @@ local function Update(self, event, unit)
 	local absorb = UnitGetTotalAbsorbs(unit) or 0
 	local healAbsorb = UnitGetTotalHealAbsorbs(unit) or 0
 	local health, maxHealth = UnitHealth(unit), UnitHealthMax(unit)
-	local overHealAbsorb = 0
-
+	local otherIncomingHeal = 0
 	local hasOverHealAbsorb = false
-	if(health < healAbsorb) then
-		overHealAbsorb = healAbsorb - health
-		healAbsorb = health
-		hasOverHealAbsorb = true
-	end
 
-	-- incoming heals shouldn't be visible if they get absorbed by the excess of
-	-- heal absorbs
-	if(overHealAbsorb > allIncomingHeal) then
+	if(healAbsorb > allIncomingHeal) then
+		healAbsorb = healAbsorb - allIncomingHeal
 		allIncomingHeal = 0
 		myIncomingHeal = 0
-	else
-		-- visible amount of all incoming heals
-		allIncomingHeal = allIncomingHeal - overHealAbsorb
 
-		if(health - healAbsorb + allIncomingHeal > maxHealth * element.maxOverflow) then
-			allIncomingHeal = maxHealth * element.maxOverflow - health + healAbsorb
+		if(health < healAbsorb) then
+			hasOverHealAbsorb = true
+			healAbsorb = health
+		end
+	else
+		allIncomingHeal = allIncomingHeal - healAbsorb
+		healAbsorb = 0
+
+		if(health + allIncomingHeal > maxHealth * element.maxOverflow) then
+			allIncomingHeal = maxHealth * element.maxOverflow - health
+		end
+
+		if(allIncomingHeal < myIncomingHeal) then
+			myIncomingHeal = allIncomingHeal
+		else
+			otherIncomingHeal = allIncomingHeal - myIncomingHeal
 		end
 	end
 
-	local otherIncomingHeal = 0
-	if(allIncomingHeal < myIncomingHeal) then
-		myIncomingHeal = allIncomingHeal
-	else
-		otherIncomingHeal = allIncomingHeal - myIncomingHeal
-	end
-
 	local hasOverAbsorb = false
-	if(health - healAbsorb + allIncomingHeal + absorb >= maxHealth or health + absorb >= maxHealth) then
+	if(health + allIncomingHeal + absorb >= maxHealth or health + absorb >= maxHealth) then
 		if(absorb > 0) then
 			hasOverAbsorb = true
 		end
 
-		if(allIncomingHeal > healAbsorb) then
-			absorb = math.max(0, maxHealth - (health - healAbsorb + allIncomingHeal))
-		else
-			absorb = math.max(0, maxHealth - health)
-		end
+		absorb = math.max(0, maxHealth - (health + allIncomingHeal))
 	end
 
 	if(element.myBar) then

--- a/elements/healthprediction.lua
+++ b/elements/healthprediction.lua
@@ -104,15 +104,27 @@ local function Update(self, event, unit)
 	local absorb = UnitGetTotalAbsorbs(unit) or 0
 	local healAbsorb = UnitGetTotalHealAbsorbs(unit) or 0
 	local health, maxHealth = UnitHealth(unit), UnitHealthMax(unit)
+	local overHealAbsorb = 0
 
 	local hasOverHealAbsorb = false
 	if(health < healAbsorb) then
-		hasOverHealAbsorb = true
+		overHealAbsorb = healAbsorb - health
 		healAbsorb = health
+		hasOverHealAbsorb = true
 	end
 
-	if(health - healAbsorb + allIncomingHeal > maxHealth * element.maxOverflow) then
-		allIncomingHeal = maxHealth * element.maxOverflow - health + healAbsorb
+	-- incoming heals shouldn't be visible if they get absorbed by the excess of
+	-- heal absorbs
+	if(overHealAbsorb > allIncomingHeal) then
+		allIncomingHeal = 0
+		myIncomingHeal = 0
+	else
+		-- visible amount of all incoming heals
+		allIncomingHeal = allIncomingHeal - overHealAbsorb
+
+		if(health - healAbsorb + allIncomingHeal > maxHealth * element.maxOverflow) then
+			allIncomingHeal = maxHealth * element.maxOverflow - health + healAbsorb
+		end
 	end
 
 	local otherIncomingHeal = 0
@@ -133,12 +145,6 @@ local function Update(self, event, unit)
 		else
 			absorb = math.max(0, maxHealth - health)
 		end
-	end
-
-	if(healAbsorb > allIncomingHeal) then
-		healAbsorb = healAbsorb - allIncomingHeal
-	else
-		healAbsorb = 0
 	end
 
 	if(element.myBar) then


### PR DESCRIPTION
Fixes maths related to heal absorb and incoming heals values. Previously we're discarding the excess of heal absorbs, while it should've been used to adjust inc heals values.

~I'll also update element's docs tomorrow, an example of `PostUpdate` is required to show people how to properly imitate Blizz prediction bars' behaviour. In our case `absorbBar` needs to be dynamically appended to either health bar or `otherBar`, depending on which one is the rightmost.~

The main difference is that inc heals and heal absorbs are mutually exclusive now. If the amount of heal absorb is larger than the amount of inc heals, its value will be adjusted and inc heals will be discarded. and vice versa.

This issue was highlighted in #409. 
  
  
  