### PR TITLE
Auras: PostUpdateIcon update

### DIFF
--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -198,7 +198,7 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 
 			if(button.overlay) then
 				if((isDebuff and element.showDebuffType) or (not isDebuff and element.showBuffType) or element.showType) then
-					local color = DebuffTypeColor[dispelType] or DebuffTypeColor.none
+					local color = DebuffTypeColor[dispelType or 'none']
 
 					button.overlay:SetVertexColor(color.r, color.g, color.b)
 					button.overlay:Show()

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -198,7 +198,7 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 
 			if(button.overlay) then
 				if((isDebuff and element.showDebuffType) or (not isDebuff and element.showBuffType) or element.showType) then
-					local color = DebuffTypeColor[debuffType or 'none']
+					local color = DebuffTypeColor[debuffType] or DebuffTypeColor.none
 
 					button.overlay:SetVertexColor(color.r, color.g, color.b)
 					button.overlay:Show()

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -138,7 +138,7 @@ local function customFilter(element, unit, button, name)
 end
 
 local function updateIcon(element, unit, index, offset, filter, isDebuff, visible)
-	local name, rank, texture, count, dispelType, duration, expiration, caster, isStealable,
+	local name, rank, texture, count, debuffType, duration, expiration, caster, isStealable,
 		nameplateShowSelf, spellID, canApply, isBossDebuff, casterIsPlayer, nameplateShowAll,
 		timeMod, effect1, effect2, effect3 = UnitAura(unit, index, filter)
 
@@ -180,7 +180,7 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 		* show - indicates whether the aura button should be shown (boolean)
 		--]]
 		local show = (element.CustomFilter or customFilter) (element, unit, button, name, rank, texture,
-			count, dispelType, duration, expiration, caster, isStealable, nameplateShowSelf, spellID,
+			count, debuffType, duration, expiration, caster, isStealable, nameplateShowSelf, spellID,
 			canApply, isBossDebuff, casterIsPlayer, nameplateShowAll,timeMod, effect1, effect2, effect3)
 
 		if(show) then
@@ -198,7 +198,7 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 
 			if(button.overlay) then
 				if((isDebuff and element.showDebuffType) or (not isDebuff and element.showBuffType) or element.showType) then
-					local color = DebuffTypeColor[dispelType or 'none']
+					local color = DebuffTypeColor[debuffType or 'none']
 
 					button.overlay:SetVertexColor(color.r, color.g, color.b)
 					button.overlay:Show()
@@ -235,11 +235,11 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 			* position    - the actual position of the aura button (number)
 			* duration    - the aura duration in seconds (number?)
 			* expiration  - the point in time when the aura will expire. Comparable to GetTime() (number)
-			* dispelType  - the dispel type of the aura (string?)['Curse', 'Disease', 'Magic', 'Poison']
+			* debuffType  - the debuff type of the aura (string?)['Curse', 'Disease', 'Magic', 'Poison']
 			* isStealable - whether the aura can be stolen or purged (boolean)
 			--]]
 			if(element.PostUpdateIcon) then
-				element:PostUpdateIcon(unit, button, index, position, duration, expiration, dispelType, isStealable)
+				element:PostUpdateIcon(unit, button, index, position, duration, expiration, debuffType, isStealable)
 			end
 
 			return VISIBLE

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -228,14 +228,18 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 			--[[ Callback: Auras:PostUpdateIcon(unit, button, index, position)
 			Called after the aura button has been updated.
 
-			* self     - the widget holding the aura buttons
-			* unit     - the unit on which the aura is cast (string)
-			* button   - the updated aura button (Button)
-			* index    - the index of the aura (number)
-			* position - the actual position of the aura button (number)
+			* self        - the widget holding the aura buttons
+			* unit        - the unit on which the aura is cast (string)
+			* button      - the updated aura button (Button)
+			* index       - the index of the aura (number)
+			* position    - the actual position of the aura button (number)
+			* duration    - the aura duration in seconds (number?)
+			* expiration  - the point in time when the aura will expire. Comparable to GetTime() (number)
+			* dispelType  - the dispel type of the aura (string?)['Curse', 'Disease', 'Magic', 'Poison']
+			* isStealable - whether the aura can be stolen or purged (boolean)
 			--]]
 			if(element.PostUpdateIcon) then
-				element:PostUpdateIcon(unit, button, index, position)
+				element:PostUpdateIcon(unit, button, index, position, duration, expiration, dispelType, isStealable)
 			end
 
 			return VISIBLE


### PR DESCRIPTION
This adds duration, expiration, dispelType and isStealable to the list of PostUpdateIcon arguments.

`duration` and `expiration` are needed by layouts for custom aura timers. This would spare them the need to call UnitAura again or use CustomFilter to access those values.

`dispelType` and `isStealable` are interesting because the auras element hides the aura border (.overlay) when the .showType/.showBuffType/.showDebuffType are not found, which is a strange behavior in the first place. So this is a way to allow layouts to react to it without breaking backwards compatibility.