### PR TITLE
pvpindicator: Default factionGroup to 'Neutral'

### DIFF
--- a/elements/pvpindicator.lua
+++ b/elements/pvpindicator.lua
@@ -51,12 +51,12 @@ local function Update(self, event, unit)
 	end
 
 	local status
-	local factionGroup = UnitFactionGroup(unit)
+	local factionGroup = UnitFactionGroup(unit) or 'Neutral'
 	local honorRewardInfo = C_PvP.GetHonorRewardInfo(UnitHonorLevel(unit))
 
 	if(UnitIsPVPFreeForAll(unit)) then
 		status = 'FFA'
-	elseif(factionGroup and factionGroup ~= 'Neutral' and UnitIsPVP(unit)) then
+	elseif(factionGroup ~= 'Neutral' and UnitIsPVP(unit)) then
 		if(unit == 'player' and UnitIsMercenary(unit)) then
 			if(factionGroup == 'Horde') then
 				factionGroup = 'Alliance'


### PR DESCRIPTION
Otherwise this error occurs in FFA arenas/brawls:
```oUF\elements\pvpindicator.lua line 77:
   attempt to concatenate local 'factionGroup' (a nil value)```