### PR TITLE
core: Remove UpdateAllElements call from DisableElement

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -141,12 +141,6 @@ for k, v in next, {
 
 		activeElements[self][name] = nil
 
-		-- We need to run a new update cycle in-case we knocked ourself out of sync.
-		-- The main reason we do this is to make sure the full update is completed
-		-- if an element for some reason removes itself _during_ the update
-		-- progress.
-		self:UpdateAllElements('DisableElement')
-
 		return elements[name].disable(self)
 	end,
 


### PR DESCRIPTION
This PR removes a 10yo hack that's no longer needed.

However, if you do need to update an element before disabling it, use its `ForceUpdate` method:
```lua
unitframe['element']:ForceUpdate()
unitframe:DisableElement('element')
```
It's similar to what you're expected to do when you need to update an element after enabling it:
```lua
unitframe:EnableElement('element')
unitframe['element']:ForceUpdate()
```