### PR TITLE
Add oUF:UnitSelectionColor(unit) method and .colorSelection option

### DIFF
--- a/colors.lua
+++ b/colors.lua
@@ -2,6 +2,8 @@ local parent, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
+local print = Private.print
+
 local frame_metatable = Private.frame_metatable
 
 local colors = {
@@ -122,6 +124,10 @@ function oUF:UnitSelectionColor(unit)
 	elseif r == 0 and g == 255 and b == 0 then
 		return self.colors.reaction[5][1], self.colors.reaction[5][2], self.colors.reaction[5][3]
 	elseif r == 0 and g == 0 and b == 255 then
+		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+	else
+		-- turns out there's still some unknown colours, default to blue for the time being
+		-- print("|cffffd200Unknown colour:|r", r, g, b)
 		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
 	end
 end

--- a/colors.lua
+++ b/colors.lua
@@ -44,6 +44,14 @@ local colors = {
 	},
 }
 
+colors.selection[255 * 65536 + 255 * 256 + 139] = colors.selection[1]
+colors.selection[255 * 65536 + 255 * 256 +   0] = colors.selection[2]
+colors.selection[255 * 65536 + 129 * 256 +   0] = colors.selection[3]
+colors.selection[255 * 65536 +   0 * 256 +   0] = colors.selection[4]
+colors.selection[128 * 65536 + 128 * 256 + 128] = colors.selection[5]
+colors.selection[  0 * 65536 + 255 * 256 +   0] = colors.selection[6]
+colors.selection[  0 * 65536 +   0 * 256 + 255] = colors.selection[7]
+
 -- We do this because people edit the vars directly, and changing the default
 -- globals makes SPICE FLOW!
 local function customClassColors()
@@ -120,34 +128,16 @@ colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
 
-local function round(v)
-	return math.floor(v + 0.5)
-end
-
 --[[ Colors: oUF:UnitSelectionColor(unit) or frame:UnitSelectionColor(unit)
 
 --]]
 function oUF:UnitSelectionColor(unit)
 	local r, g, b = UnitSelectionColor(unit)
-	r, g, b = round(r * 255), round(g * 255), round(b * 255)
+	r = math.ceil(r * 255) * 65536 + math.ceil(g * 255) * 256 + math.ceil(b * 255)
 
-	local color
-	if(r == 255 and g == 255 and b == 139) then
-		color = self.colors.selection[1]
-	elseif(r == 255 and g == 255 and b == 0) then
-		color = self.colors.selection[2]
-	elseif(r == 255 and g == 129 and b == 0) then
-		color = self.colors.selection[3]
-	elseif(r == 255 and g == 0 and b == 0) then
-		color = self.colors.selection[4]
-	elseif(r == 128 and g == 128 and b == 128) then
-		color = self.colors.selection[5]
-	elseif(r == 0 and g == 255 and b == 0) then
-		color = self.colors.selection[6]
-	elseif(r == 0 and g == 0 and b == 255) then
-		color = self.colors.selection[7]
-	else
-		-- print("|cffffd200Unknown colour:|r", r, g, b)
+	local color = self.colors.selection[r]
+	if(not color) then
+		-- print("|cffffd200Unknown colour:|r", UnitSelectionColor(unit))
 		color = self.colors.selection[7]
 	end
 

--- a/colors.lua
+++ b/colors.lua
@@ -30,7 +30,7 @@ local colors = {
 		{255 / 255, 255 / 255, 139 / 255},
 		-- yellow, used for neutral units
 		{255 / 255, 255 / 255, 0 / 255},
-		-- orange, used for non-interactive unfriendly units
+		-- orange, used for unfriendly units
 		{255 / 255, 129 / 255, 0 / 255},
 		-- red, used for hostile units
 		{255 / 255, 0 / 255, 0 /255},
@@ -38,8 +38,7 @@ local colors = {
 		{128 / 255, 128 / 255, 128 / 255},
 		-- green, used for friendly units
 		{0 / 255, 255 / 255, 0 / 255},
-		-- blue, the default colour, also used for friendly player names in dungeons, unattackable
-		-- players in sanctuaries, etc.
+		-- blue, the default colour, mainly used for players in dungeons, raids, and sanctuaries
 		{0 / 255, 0 / 255, 255 / 255},
 	},
 }
@@ -134,6 +133,12 @@ colors.power[18] = colors.power.PAIN
 function oUF:UnitSelectionColor(unit)
 	local r, g, b = UnitSelectionColor(unit)
 	r = math.ceil(r * 255) * 65536 + math.ceil(g * 255) * 256 + math.ceil(b * 255)
+
+	-- BUG: When targeting yourself while in combat, UnitSelectionColor for "player" or any other unit that's actually
+	-- player returns either green or blue instead of intended light yellow
+	if(UnitIsUnit(unit, 'player') and UnitAffectingCombat('player')) then
+		r = 16777099 -- 255 * 65536 + 255 * 256 + 139
+	end
 
 	local color = self.colors.selection[r]
 	if(not color) then

--- a/colors.lua
+++ b/colors.lua
@@ -22,10 +22,26 @@ local colors = {
 	},
 	class = {},
 	debuff = {},
-	reaction = {
-		[0] = {0, 0, 1},
-	},
+	reaction = {},
 	power = {},
+	selection = {
+		-- these colours are sorted by r, then by g, then by b
+		-- very light yellow, used for player's character while in combat
+		{255 / 255, 255 / 255, 139 / 255},
+		-- yellow, used for neutral units
+		{255 / 255, 255 / 255, 0 / 255},
+		-- orange, used for non-interactive unfriendly units
+		{255 / 255, 129 / 255, 0 / 255},
+		-- red, used for hostile units
+		{255 / 255, 0 / 255, 0 /255},
+		-- grey, used for dead units
+		{128 / 255, 128 / 255, 128 / 255},
+		-- green, used for friendly units
+		{0 / 255, 255 / 255, 0 / 255},
+		-- blue, the default colour, also used for friendly player names in dungeons, unattackable
+		-- players in sanctuaries, etc.
+		{0 / 255, 0 / 255, 255 / 255},
+	},
 }
 
 -- We do this because people edit the vars directly, and changing the default
@@ -115,21 +131,27 @@ function oUF:UnitSelectionColor(unit)
 	local r, g, b = UnitSelectionColor(unit)
 	r, g, b = round(r * 255), round(g * 255), round(b * 255)
 
-	if r == 255 and g == 255 and b == 0 then
-		return self.colors.reaction[4][1], self.colors.reaction[4][2], self.colors.reaction[4][3]
-	elseif r == 255 and g == 129 and b == 0 then
-		return self.colors.reaction[3][1], self.colors.reaction[3][2], self.colors.reaction[3][3]
-	elseif r == 255 and g == 0 and b == 0 then
-		return self.colors.reaction[2][1], self.colors.reaction[2][2], self.colors.reaction[2][3]
-	elseif r == 0 and g == 255 and b == 0 then
-		return self.colors.reaction[5][1], self.colors.reaction[5][2], self.colors.reaction[5][3]
-	elseif r == 0 and g == 0 and b == 255 then
-		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+	local color
+	if(r == 255 and g == 255 and b == 139) then
+		color = self.colors.selection[1]
+	elseif(r == 255 and g == 255 and b == 0) then
+		color = self.colors.selection[2]
+	elseif(r == 255 and g == 129 and b == 0) then
+		color = self.colors.selection[3]
+	elseif(r == 255 and g == 0 and b == 0) then
+		color = self.colors.selection[4]
+	elseif(r == 128 and g == 128 and b == 128) then
+		color = self.colors.selection[5]
+	elseif(r == 0 and g == 255 and b == 0) then
+		color = self.colors.selection[6]
+	elseif(r == 0 and g == 0 and b == 255) then
+		color = self.colors.selection[7]
 	else
-		-- turns out there's still some unknown colours, default to blue for the time being
 		-- print("|cffffd200Unknown colour:|r", r, g, b)
-		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+		color = self.colors.selection[7]
 	end
+
+	return color[1], color[2], color[3]
 end
 
 local function colorsAndPercent(a, b, ...)

--- a/colors.lua
+++ b/colors.lua
@@ -153,7 +153,7 @@ local function colorsAndPercent(a, b, ...)
 	if(a <= 0 or b == 0) then
 		return nil, ...
 	elseif(a >= b) then
-		return nil, select(select('#', ...) - 2, ...)
+		return nil, select(-3, ...)
 	end
 
 	local num = select('#', ...) / 3

--- a/colors.lua
+++ b/colors.lua
@@ -20,7 +20,9 @@ local colors = {
 	},
 	class = {},
 	debuff = {},
-	reaction = {},
+	reaction = {
+		[0] = {0, 0, 1},
+	},
 	power = {},
 }
 
@@ -99,6 +101,30 @@ colors.power[13] = colors.power.INSANITY
 colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
+
+local function round(v)
+	return math.floor(v + 0.5)
+end
+
+--[[ Colors: oUF:UnitSelectionColor(unit) or frame:UnitSelectionColor(unit)
+
+--]]
+function oUF:UnitSelectionColor(unit)
+	local r, g, b = UnitSelectionColor(unit)
+	r, g, b = round(r * 255), round(g * 255), round(b * 255)
+
+	if r == 255 and g == 255 and b == 0 then
+		return self.colors.reaction[4][1], self.colors.reaction[4][2], self.colors.reaction[4][3]
+	elseif r == 255 and g == 129 and b == 0 then
+		return self.colors.reaction[3][1], self.colors.reaction[3][2], self.colors.reaction[3][3]
+	elseif r == 255 and g == 0 and b == 0 then
+		return self.colors.reaction[2][1], self.colors.reaction[2][2], self.colors.reaction[2][3]
+	elseif r == 0 and g == 255 and b == 0 then
+		return self.colors.reaction[5][1], self.colors.reaction[5][2], self.colors.reaction[5][3]
+	elseif r == 0 and g == 0 and b == 255 then
+		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+	end
+end
 
 local function colorsAndPercent(a, b, ...)
 	if(a <= 0 or b == 0) then
@@ -245,3 +271,4 @@ oUF.useHCYColorGradient = false
 
 frame_metatable.__index.colors = colors
 frame_metatable.__index.ColorGradient = oUF.ColorGradient
+frame_metatable.__index.UnitSelectionColor = oUF.UnitSelectionColor

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -196,6 +196,7 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_MAXHEALTH', Path)
 		self:RegisterEvent('UNIT_CONNECTION', Path)
 		self:RegisterEvent('UNIT_FACTION', Path) -- For tapping
+		self:RegisterEvent('UNIT_FLAGS', Path) -- For selection
 
 		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
@@ -221,6 +222,7 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_MAXHEALTH', Path)
 		self:UnregisterEvent('UNIT_CONNECTION', Path)
 		self:UnregisterEvent('UNIT_FACTION', Path)
+		self:UnregisterEvent('UNIT_FLAGS', Path)
 	end
 end
 

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -29,6 +29,7 @@ The following options are listed by priority. The first check that returns true 
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
+.colorSelection    - ??? (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)
@@ -91,6 +92,8 @@ local function UpdateColor(element, unit, cur, max)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
+	elseif(element.colorSelection) then
+		r, g, b = parent:UnitSelectionColor(unit)
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -270,6 +270,7 @@ local function Enable(self)
 		self:RegisterEvent('UNIT_CONNECTION', Path)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)
 		self:RegisterEvent('UNIT_FACTION', Path) -- For tapping
+		self:RegisterEvent('UNIT_FLAGS', Path) -- For selection
 
 		if(element:IsObjectType('StatusBar')) then
 			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
@@ -299,6 +300,7 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_CONNECTION', Path)
 		self:UnregisterEvent('UNIT_MAXPOWER', Path)
 		self:UnregisterEvent('UNIT_FACTION', Path)
+		self:UnregisterEvent('UNIT_FLAGS', Path)
 	end
 end
 

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -42,6 +42,7 @@ The following options are listed by priority. The first check that returns true 
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
+.colorSelection    - ??? (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)
@@ -133,6 +134,8 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
+	elseif(element.colorSelection) then
+		r, g, b = parent:UnitSelectionColor(unit)
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then


### PR DESCRIPTION
Blizz UI no longer uses `FACTION_BAR_COLORS` for unit frames' or nameplates' name colouring, instead, it uses `UnitSelectionColor` method. It's been this way since Legion.

`oUF:UnitSelectionColor(unit)` is a wrapper for `UnitSelectionColor` that allows us to use custom colours from the `oUF.colors.reacation` table.

~Technically, we could replace `.colorReputation` w/ this, but more options = more better, ayy\~ :grin::gun:~

No docs yet.

-- update 1

~K, since other colours have been discovered, reusing `oUF.colors.reaction` is no longer reasonable, so I'll create a new table for it.~

~List of colours I haven't added to the wrapper function yet:~
~- `255, 255, 139` - the colour for your own char while in combat;~
~- `128, 128, 128` - the colour for dead units.~

-- update 2

Rewrote the whole thing, still no docs, trying to catch all the colours.

"Selection" is a character's outline and a circle underneath, this method returns its colour.