### PR TITLE
Always show combo point backgrounds

### DIFF
--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -133,11 +133,13 @@ local function Update(self, event, unit, powerType)
 
 		oldMax = element.__max
 		if(max ~= oldMax) then
-			for i = max + 1, oldMax do
-				if(max < oldMax) then
+			if(max < oldMax) then
+				for i = max + 1, oldMax do
 					element[i]:Hide()
 					element[i]:SetValue(0)
-				else
+				end
+			else
+				for i = oldMax + 1, max do
 					element[i]:Show()
 				end
 			end
@@ -234,6 +236,11 @@ do
 	function ClassPowerEnable(self)
 		self:RegisterEvent('UNIT_POWER_FREQUENT', Path)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)
+
+		local element = self.ClassPower
+		for i = 1, #element do
+			element[i]:Show()
+		end
 
 		self.ClassPower.isEnabled = true
 

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -125,20 +125,20 @@ local function Update(self, event, unit, powerType)
 		local numActive = cur + 0.9
 		for i = 1, max do
 			if(i > numActive) then
-				element[i]:Hide()
 				element[i]:SetValue(0)
 			else
-				element[i]:Show()
 				element[i]:SetValue(cur - i + 1)
 			end
 		end
 
 		oldMax = element.__max
 		if(max ~= oldMax) then
-			if(max < oldMax) then
-				for i = max + 1, oldMax do
+			for i = max + 1, oldMax do
+				if(max < oldMax) then
 					element[i]:Hide()
 					element[i]:SetValue(0)
+				else
+					element[i]:Show()
 				end
 			end
 


### PR DESCRIPTION
Hiding classpower bars when inactive overrides the desired behavior of showing the "empty" bar background meaning that the empty bars only show up on login/reload. After the first time Update is called, they're always either active or entirely invisible.