### PR TITLE
readycheckindicator: fix the match pattern

### DIFF
--- a/elements/readycheckindicator.lua
+++ b/elements/readycheckindicator.lua
@@ -122,7 +122,7 @@ end
 
 local function Enable(self, unit)
 	local element = self.ReadyCheckIndicator
-	unit = unit and unit:match('(%a+)%d+$')
+	unit = unit and unit:match('(%a+)%d*$')
 	if(element and (unit == 'party' or unit == 'raid')) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate


### PR DESCRIPTION
Header units are either `party` or `raid`.

See https://github.com/oUF-wow/oUF/commit/4a13cf0d7b749d072c10eb99a7fa9e8c82c8de3c#commitcomment-31804926