### PR TITLE
core: keep the event table even with one handler left

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -133,9 +133,9 @@ function frame_metatable.__index:UnregisterEvent(event, func)
 	if(type(curev) == 'table' and func) then
 		for k, infunc in next, curev do
 			if(infunc == func) then
-				table.remove(curev, k)
+				curev[k] = nil
 
-				if(#curev == 0) then
+				if(not next(curev)) then
 					cleanUp = true
 				end
 

--- a/events.lua
+++ b/events.lua
@@ -134,13 +134,12 @@ function frame_metatable.__index:UnregisterEvent(event, func)
 		for k, infunc in next, curev do
 			if(infunc == func) then
 				curev[k] = nil
-
-				if(not next(curev)) then
-					cleanUp = true
-				end
-
 				break
 			end
+		end
+
+		if(not next(curev)) then
+			cleanUp = true
 		end
 	end
 

--- a/events.lua
+++ b/events.lua
@@ -128,25 +128,23 @@ Used to remove a function from the event handler list for a game event.
 function frame_metatable.__index:UnregisterEvent(event, func)
 	argcheck(event, 2, 'string')
 
+	local cleanUp = false
 	local curev = self[event]
 	if(type(curev) == 'table' and func) then
 		for k, infunc in next, curev do
 			if(infunc == func) then
 				table.remove(curev, k)
 
-				local n = #curev
-				if(n == 1) then
-					local _, handler = next(curev)
-					self[event] = handler
-				elseif(n == 0) then
-					-- This should not happen
-					unregisterEvent(self, event)
+				if(#curev == 0) then
+					cleanUp = true
 				end
 
 				break
 			end
 		end
-	elseif(curev == func) then
+	end
+
+	if(cleanUp or curev == func) then
 		self[event] = nil
 		if(self.unitEvents) then
 			self.unitEvents[event] = nil

--- a/private.lua
+++ b/private.lua
@@ -29,12 +29,10 @@ local validator = CreateFrame('Frame')
 
 function Private.validateUnit(unit)
 	local isOK, _ = pcall(validator.RegisterUnitEvent, validator, 'UNIT_HEALTH', unit)
-	if isOK then
+	if(isOK) then
 		_, unit = validator:IsEventRegistered('UNIT_HEALTH')
-		if unit then
-			validator:UnregisterEvent('UNIT_HEALTH')
+		validator:UnregisterEvent('UNIT_HEALTH')
 
-			return true
-		end
+		return not not unit
 	end
 end


### PR DESCRIPTION
Fixes the case were for an event with N handlers, N - 1 become unregistered during the execution loop. Before the patch in this case the handler table was converted to a function causing the for loop in the __call meta method to exit without calling it.