### PR TITLE
core: allow elements to be overridden

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -802,7 +802,6 @@ function oUF:AddElement(name, update, enable, disable)
 	argcheck(enable, 4, 'function', 'nil')
 	argcheck(disable, 5, 'function', 'nil')
 
-	if(elements[name]) then return error('Element [%s] is already registered.', name) end
 	elements[name] = {
 		update = update;
 		enable = enable;


### PR DESCRIPTION
This will help with debugging custom elements vs default elements without having to change the name each time.