### PR TITLE
castbar: Element revamp

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -395,7 +395,7 @@ local function Enable(self, unit)
 
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 
-		if(self.unit == 'player' and not (self.hasChildren or self.isChild)) then
+		if(self.unit == 'player' and not (self.hasChildren or self.isChild or self.isNamePlate)) then
 			CastingBarFrame_SetUnit(CastingBarFrame, nil)
 			CastingBarFrame_SetUnit(PetCastingBarFrame, nil)
 		end
@@ -443,7 +443,7 @@ local function Disable(self)
 
 		element:SetScript('OnUpdate', nil)
 
-		if(self.unit == 'player' and not (self.hasChildren or self.isChild)) then
+		if(self.unit == 'player' and not (self.hasChildren or self.isChild or self.isNamePlate)) then
 			CastingBarFrame_OnLoad(CastingBarFrame, 'player', true, false)
 			PetCastingBarFrame_OnLoad(PetCastingBarFrame)
 		end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -391,6 +391,8 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
 		self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 
+		element.holdTime = 0
+
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 
 		if(self.unit == 'player' and not (self.hasChildren or self.isChild)) then

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -22,17 +22,17 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 
 ## Options
 
-.timeToHold      - indicates for how many seconds the castbar should be visible after a _FAILED or _INTERRUPTED
+.timeToHold      - Indicates for how many seconds the castbar should be visible after a _FAILED or _INTERRUPTED
                    event. Defaults to 0 (number)
-.hideTradeSkills - makes the element ignore casts related to crafting professions (boolean)
+.hideTradeSkills - Makes the element ignore casts related to crafting professions (boolean)
 
 ## Attributes
 
-.castID           - a globally unique identifier of the currently cast spell (string?)
-.casting          - indicates whether the current spell is an ordinary cast (boolean)
-.channeling       - indicates whether the current spell is a channeled cast (boolean)
-.notInterruptible - indicates whether the current spell is interruptible (boolean)
-.spellID          - the spell identifier of the currently cast/channeled spell (number)
+.castID           - A globally unique identifier of the currently cast spell (string?)
+.casting          - Indicates whether the current spell is an ordinary cast (boolean)
+.channeling       - Indicates whether the current spell is a channeled cast (boolean)
+.notInterruptible - Indicates whether the current spell is interruptible (boolean)
+.spellID          - The spell identifier of the currently cast/channeled spell (number)
 
 ## Examples
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -393,7 +393,7 @@ local function Enable(self, unit)
 
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 
-		if(self.unit == 'player') then
+		if(self.unit == 'player' and not (self.hasChildren or self.isChild)) then
 			CastingBarFrame_SetUnit(CastingBarFrame, nil)
 			CastingBarFrame_SetUnit(PetCastingBarFrame, nil)
 		end
@@ -441,7 +441,7 @@ local function Disable(self)
 
 		element:SetScript('OnUpdate', nil)
 
-		if(self.unit == 'player') then
+		if(self.unit == 'player' and not (self.hasChildren or self.isChild)) then
 			CastingBarFrame_OnLoad(CastingBarFrame, 'player', true, false)
 			PetCastingBarFrame_OnLoad(PetCastingBarFrame)
 		end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -23,7 +23,7 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 
 .timeToHold      - indicates for how many seconds the castbar should be visible after a _FAILED or _INTERRUPTED
                    event. Defaults to 0 (number)
-.hideTradeSkills - makes the element ignore casts related to crafted professions (boolean)
+.hideTradeSkills - makes the element ignore casts related to crafting professions (boolean)
 
 ## Attributes
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -344,15 +344,14 @@ local function onUpdate(self, elapsed)
 		self:SetValue(duration)
 
 		if(self.Spark) then
-			local horiz = self.horizontal
-			local size = self[horiz and 'GetWidth' or 'GetHeight'](self)
-
+			local isHoriz = self.isHorizontal
+			local size = self[isHoriz and 'GetWidth' or 'GetHeight'](self)
 			local offset = (duration / self.max) * size
-			if(self:GetReverseFill()) then
+			if(self.isReversed) then
 				offset = size - offset
 			end
 
-			self.Spark:SetPoint('CENTER', self, horiz and 'LEFT' or 'BOTTOM', horiz and offset or 0, horiz and 0 or offset)
+			self.Spark:SetPoint('CENTER', self, isHoriz and 'LEFT' or 'BOTTOM', isHoriz and offset or 0, isHoriz and 0 or offset)
 		end
 	elseif(self.channeling) then
 		local duration = self.duration - elapsed
@@ -384,15 +383,14 @@ local function onUpdate(self, elapsed)
 		self.duration = duration
 		self:SetValue(duration)
 		if(self.Spark) then
-			local horiz = self.horizontal
-			local size = self[horiz and 'GetWidth' or 'GetHeight'](self)
-
+			local isHoriz = self.isHorizontal
+			local size = self[isHoriz and 'GetWidth' or 'GetHeight'](self)
 			local offset = (duration / self.max) * size
-			if(self:GetReverseFill()) then
+			if(self.isReversed) then
 				offset = size - offset
 			end
 
-			self.Spark:SetPoint('CENTER', self, horiz and 'LEFT' or 'BOTTOM', horiz and offset or 0, horiz and 0 or offset)
+			self.Spark:SetPoint('CENTER', self, isHoriz and 'LEFT' or 'BOTTOM', isHoriz and offset or 0, isHoriz and 0 or offset)
 		end
 	elseif(self.holdTime > 0) then
 		self.holdTime = self.holdTime - elapsed
@@ -432,7 +430,6 @@ local function Enable(self, unit)
 			self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 		end
 
-		element.horizontal = element:GetOrientation() == 'HORIZONTAL'
 		element.holdTime = 0
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -9,11 +9,12 @@ Castbar - A `StatusBar` to represent spell cast/channel progress.
 
 ## Sub-Widgets
 
-.Text     - A `FontString` to represent spell name.
 .Icon     - A `Texture` to represent spell icon.
-.Time     - A `FontString` to represent spell duration.
-.Shield   - A `Texture` to represent if it's possible to interrupt or spell steal.
 .SafeZone - A `Texture` to represent latency.
+.Shield   - A `Texture` to represent if it's possible to interrupt or spell steal.
+.Spark    - A `Texture` to represent the castbar's edge.
+.Text     - A `FontString` to represent spell name.
+.Time     - A `FontString` to represent spell duration.
 
 ## Notes
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -286,16 +286,15 @@ local function CastFail(self, event, unit, castID, spellID)
 	end
 end
 
-local function UNIT_SPELLCAST_INTERRUPTIBLE(self, event, unit)
+local function CastInterruptible(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local element = self.Castbar
-	local shield = element.Shield
-	if(shield) then
-		shield:Hide()
-	end
+	if(not element:IsShown()) then return end
 
-	element.notInterruptible = nil
+	element.notInterruptible = event == 'UNIT_SPELLCAST_NOT_INTERRUPTIBLE'
+
+	if(element.Shield) then element.Shield:SetShown(element.notInterruptible) end
 
 	--[[ Callback: Castbar:PostCastInterruptible(unit)
 	Called after the element has been updated when a spell cast has become interruptible.
@@ -305,28 +304,6 @@ local function UNIT_SPELLCAST_INTERRUPTIBLE(self, event, unit)
 	--]]
 	if(element.PostCastInterruptible) then
 		return element:PostCastInterruptible(unit)
-	end
-end
-
-local function UNIT_SPELLCAST_NOT_INTERRUPTIBLE(self, event, unit)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
-
-	local element = self.Castbar
-	local shield = element.Shield
-	if(shield) then
-		shield:Show()
-	end
-
-	element.notInterruptible = true
-
-	--[[ Callback: Castbar:PostCastNotInterruptible(unit)
-	Called after the element has been updated when a spell cast has become non-interruptible.
-
-	* self - the Castbar widget
-	* unit - unit for which the update has been triggered (string)
-	--]]
-	if(element.PostCastNotInterruptible) then
-		return element:PostCastNotInterruptible(unit)
 	end
 end
 
@@ -445,9 +422,8 @@ local function Enable(self, unit)
 			self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
 			self:RegisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
-
-			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', UNIT_SPELLCAST_INTERRUPTIBLE)
-			self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
+			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
+			self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 		end
 
 		element.horizontal = element:GetOrientation() == 'HORIZONTAL'
@@ -502,9 +478,8 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
 		self:UnregisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
-
-		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', UNIT_SPELLCAST_INTERRUPTIBLE)
-		self:UnregisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
+		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
+		self:UnregisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 
 		element:SetScript('OnUpdate', nil)
 	end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -119,7 +119,12 @@ local function CastStart(self, event, unit)
 		name, _, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID = UnitChannelInfo(unit)
 		event = 'UNIT_SPELLCAST_CHANNEL_START'
 
-		if(not name) then return end
+		if(not name) then
+			resetAttributes(element)
+			element:Hide()
+
+			return
+		end
 	end
 
 	endTime = endTime / 1e3

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -173,15 +173,14 @@ local function CastStart(self, event, unit)
 		safeZone:SetWidth(element[isHoriz and 'GetWidth' or 'GetHeight'](element) * ratio)
 	end
 
-	--[[ Callback: Castbar:PostCastStart(unit, name)
+	--[[ Callback: Castbar:PostCastStart(unit)
 	Called after the element has been updated upon a spell cast start.
 
 	* self - the Castbar widget
 	* unit - unit for which the update has been triggered (string)
-	* name - name of the spell being cast (string)
 	--]]
 	if(element.PostCastStart) then
-		element:PostCastStart(unit, name)
+		element:PostCastStart(unit)
 	end
 
 	element:Show()

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -51,6 +51,7 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
     local Spark = Castbar:CreateTexture(nil, 'OVERLAY')
     Spark:SetSize(20, 20)
     Spark:SetBlendMode('ADD')
+    Spark:SetPoint("CENTER", Castbar:GetStatusBarTexture(), "RIGHT", 0, 0)
 
     -- Add a timer
     local Time = Castbar:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall')
@@ -346,17 +347,6 @@ local function onUpdate(self, elapsed)
 
 		self.duration = duration
 		self:SetValue(duration)
-
-		if(self.Spark) then
-			local isHoriz = self.isHorizontal
-			local size = self[isHoriz and 'GetWidth' or 'GetHeight'](self)
-			local offset = (duration / self.max) * size
-			if(self.isReversed) then
-				offset = size - offset
-			end
-
-			self.Spark:SetPoint('CENTER', self, isHoriz and 'LEFT' or 'BOTTOM', isHoriz and offset or 0, isHoriz and 0 or offset)
-		end
 	elseif(self.channeling) then
 		local duration = self.duration - elapsed
 		if(duration <= 0) then
@@ -388,17 +378,6 @@ local function onUpdate(self, elapsed)
 
 		self.duration = duration
 		self:SetValue(duration)
-
-		if(self.Spark) then
-			local isHoriz = self.isHorizontal
-			local size = self[isHoriz and 'GetWidth' or 'GetHeight'](self)
-			local offset = (duration / self.max) * size
-			if(self.isReversed) then
-				offset = size - offset
-			end
-
-			self.Spark:SetPoint('CENTER', self, isHoriz and 'LEFT' or 'BOTTOM', isHoriz and offset or 0, isHoriz and 0 or offset)
-		end
 	elseif(self.holdTime > 0) then
 		self.holdTime = self.holdTime - elapsed
 	else

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -439,11 +439,9 @@ local function Enable(self, unit)
 
 		if(self.unit == 'player') then
 			CastingBarFrame:UnregisterAllEvents()
-			CastingBarFrame.Show = CastingBarFrame.Hide
 			CastingBarFrame:Hide()
 
 			PetCastingBarFrame:UnregisterAllEvents()
-			PetCastingBarFrame.Show = PetCastingBarFrame.Hide
 			PetCastingBarFrame:Hide()
 		end
 
@@ -489,6 +487,11 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 
 		element:SetScript('OnUpdate', nil)
+
+		if(self.unit == 'player') then
+			CastingBarFrame_OnLoad(CastingBarFrame, "player", true, false)
+			PetCastingBarFrame_OnLoad(PetCastingBarFrame)
+		end
 	end
 end
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -91,6 +91,14 @@ local GetTime = GetTime
 local UnitCastingInfo = UnitCastingInfo
 local UnitChannelInfo = UnitChannelInfo
 
+local function resetAttributes(self)
+	self.castID = nil
+	self.casting = nil
+	self.channeling = nil
+	self.notInterruptible = nil
+	self.spellID = nil
+end
+
 local function CastStart(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
@@ -189,10 +197,7 @@ local function CastStop(self, event, unit, castID, spellID)
 
 	if(element.Spark) then element.Spark:Hide() end
 
-	element.casting = nil
-	element.channeling = nil
-	element.notInterruptible = nil
-
+	resetAttributes(element)
 	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastStop(unit)
@@ -274,11 +279,9 @@ local function CastFail(self, event, unit, castID, spellID)
 
 	if(element.Spark) then element.Spark:Hide() end
 
-	element.casting = nil
-	element.channeling = nil
-	element.notInterruptible = nil
 	element.holdTime = element.timeToHold or 0
 
+	resetAttributes(element)
 	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastFailed(unit)
@@ -317,10 +320,13 @@ local function onUpdate(self, elapsed)
 	if(self.casting) then
 		local duration = self.duration + elapsed
 		if(duration >= self.max) then
-			self.casting = nil
+			resetAttributes(self)
 			self:Hide()
 
-			if(self.PostCastStop) then self:PostCastStop(self.__owner.unit) end
+			if(self.PostCastStop) then
+				self:PostCastStop(self.__owner.unit)
+			end
+
 			return
 		end
 
@@ -355,12 +361,14 @@ local function onUpdate(self, elapsed)
 		end
 	elseif(self.channeling) then
 		local duration = self.duration - elapsed
-
 		if(duration <= 0) then
-			self.channeling = nil
+			resetAttributes(self)
 			self:Hide()
 
-			if(self.PostChannelStop) then self:PostChannelStop(self.__owner.unit) end
+			if(self.PostChannelStop) then
+				self:PostChannelStop(self.__owner.unit)
+			end
+
 			return
 		end
 
@@ -382,6 +390,7 @@ local function onUpdate(self, elapsed)
 
 		self.duration = duration
 		self:SetValue(duration)
+
 		if(self.Spark) then
 			local isHoriz = self.isHorizontal
 			local size = self[isHoriz and 'GetWidth' or 'GetHeight'](self)
@@ -395,10 +404,7 @@ local function onUpdate(self, elapsed)
 	elseif(self.holdTime > 0) then
 		self.holdTime = self.holdTime - elapsed
 	else
-		self.casting = nil
-		self.castID = nil
-		self.channeling = nil
-
+		resetAttributes(self)
 		self:Hide()
 	end
 end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -316,68 +316,51 @@ local function CastInterruptible(self, event, unit)
 end
 
 local function onUpdate(self, elapsed)
-	if(self.casting) then
-		local duration = self.duration + elapsed
-		if(duration >= self.max) then
-			resetAttributes(self)
-			self:Hide()
+	if(self.casting or self.channeling) then
+		local isCasting = self.casting
+		if(isCasting) then
+			self.duration = self.duration + elapsed
+			if(self.duration >= self.max) then
+				resetAttributes(self)
+				self:Hide()
 
-			if(self.PostCastStop) then
-				self:PostCastStop(self.__owner.unit)
+				if(self.PostCastStop) then
+					self:PostCastStop(self.__owner.unit)
+				end
+
+				return
 			end
+		else
+			self.duration = self.duration - elapsed
+			if(self.duration <= 0) then
+				resetAttributes(self)
+				self:Hide()
 
-			return
+				if(self.PostCastStop) then
+					self:PostCastStop(self.__owner.unit)
+				end
+
+				return
+			end
 		end
 
 		if(self.Time) then
 			if(self.delay ~= 0) then
 				if(self.CustomDelayText) then
-					self:CustomDelayText(duration)
+					self:CustomDelayText(self.duration)
 				else
-					self.Time:SetFormattedText('%.1f|cffff0000+%.2f|r', duration, self.delay)
+					self.Time:SetFormattedText('%.1f|cffff0000%s%.2f|r', self.duration, isCasting and '+' or '-', self.delay)
 				end
 			else
 				if(self.CustomTimeText) then
-					self:CustomTimeText(duration)
+					self:CustomTimeText(self.duration)
 				else
-					self.Time:SetFormattedText('%.1f', duration)
+					self.Time:SetFormattedText('%.1f', self.duration)
 				end
 			end
 		end
 
-		self.duration = duration
-		self:SetValue(duration)
-	elseif(self.channeling) then
-		local duration = self.duration - elapsed
-		if(duration <= 0) then
-			resetAttributes(self)
-			self:Hide()
-
-			if(self.PostChannelStop) then
-				self:PostChannelStop(self.__owner.unit)
-			end
-
-			return
-		end
-
-		if(self.Time) then
-			if(self.delay ~= 0) then
-				if(self.CustomDelayText) then
-					self:CustomDelayText(duration)
-				else
-					self.Time:SetFormattedText('%.1f|cffff0000-%.2f|r', duration, self.delay)
-				end
-			else
-				if(self.CustomTimeText) then
-					self:CustomTimeText(duration)
-				else
-					self.Time:SetFormattedText('%.1f', duration)
-				end
-			end
-		end
-
-		self.duration = duration
-		self:SetValue(duration)
+		self:SetValue(self.duration)
 	elseif(self.holdTime > 0) then
 		self.holdTime = self.holdTime - elapsed
 	else

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -191,14 +191,15 @@ local function CastStop(self, event, unit, castID, spellID)
 	resetAttributes(element)
 	element:SetValue(element.max)
 
-	--[[ Callback: Castbar:PostCastStop(unit)
+	--[[ Callback: Castbar:PostCastStop(unit, spellID)
 	Called after the element has been updated when a spell cast has stopped.
 
-	* self - the Castbar widget
-	* unit - unit for which the update has been triggered (string)
+	* self    - the Castbar widget
+	* unit    - unit for which the update has been triggered (string)
+	* spellID - the ID of the spell (number)
 	--]]
 	if(element.PostCastStop) then
-		return element:PostCastStop(unit)
+		return element:PostCastStop(unit, spellID)
 	end
 end
 
@@ -274,14 +275,15 @@ local function CastFail(self, event, unit, castID, spellID)
 	resetAttributes(element)
 	element:SetValue(element.max)
 
-	--[[ Callback: Castbar:PostCastFail(unit)
+	--[[ Callback: Castbar:PostCastFail(unit, spellID)
 	Called after the element has been updated upon a failed spell cast.
 
-	* self - the Castbar widget
-	* unit - unit for which the update has been triggered (string)
+	* self    - the Castbar widget
+	* unit    - unit for which the update has been triggered (string)
+	* spellID - the ID of the spell (number)
 	--]]
 	if(element.PostCastFail) then
-		return element:PostCastFail(unit)
+		return element:PostCastFail(unit, spellID)
 	end
 end
 
@@ -312,11 +314,13 @@ local function onUpdate(self, elapsed)
 		if(isCasting) then
 			self.duration = self.duration + elapsed
 			if(self.duration >= self.max) then
+				local spellID = self.spellID
+
 				resetAttributes(self)
 				self:Hide()
 
 				if(self.PostCastStop) then
-					self:PostCastStop(self.__owner.unit)
+					self:PostCastStop(self.__owner.unit, spellID)
 				end
 
 				return
@@ -324,11 +328,13 @@ local function onUpdate(self, elapsed)
 		else
 			self.duration = self.duration - elapsed
 			if(self.duration <= 0) then
+				local spellID = self.spellID
+
 				resetAttributes(self)
 				self:Hide()
 
 				if(self.PostCastStop) then
-					self:PostCastStop(self.__owner.unit)
+					self:PostCastStop(self.__owner.unit, spellID)
 				end
 
 				return

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -89,6 +89,8 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 local _, ns = ...
 local oUF = ns.oUF
 
+local DEFAULT_ICON = [[Interface\ICONS\INV_Misc_QuestionMark]]
+
 local function resetAttributes(self)
 	self.castID = nil
 	self.casting = nil
@@ -138,7 +140,7 @@ local function CastStart(self, event, unit)
 	element:SetMinMaxValues(0, element.max)
 	element:SetValue(0)
 
-	if(element.Icon) then element.Icon:SetTexture(texture or [[Interface\ICONS\INV_Misc_QuestionMark]]) end
+	if(element.Icon) then element.Icon:SetTexture(texture or DEFAULT_ICON) end
 	if(element.Shield) then element.Shield:SetShown(notInterruptible) end
 	if(element.Spark) then element.Spark:Show() end
 	if(element.Text) then element.Text:SetText(name) end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -138,7 +138,7 @@ local function CastStart(self, event, unit)
 	end
 
 	element:SetMinMaxValues(0, element.max)
-	element:SetValue(0)
+	element:SetValue(element.duration)
 
 	if(element.Icon) then element.Icon:SetTexture(texture or DEFAULT_ICON) end
 	if(element.Shield) then element.Shield:SetShown(notInterruptible) end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -197,7 +197,7 @@ local function CastStop(self, event, unit, castID, spellID)
 	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastStop(unit)
-	Called after the element has been updated when a spell cast has finished.
+	Called after the element has been updated when a spell cast has stopped.
 
 	* self - the Castbar widget
 	* unit - unit for which the update has been triggered (string)
@@ -301,7 +301,7 @@ local function CastInterruptible(self, event, unit)
 	if(element.Shield) then element.Shield:SetShown(element.notInterruptible) end
 
 	--[[ Callback: Castbar:PostCastInterruptible(unit)
-	Called after the element has been updated when a spell cast has become interruptible.
+	Called after the element has been updated when a spell cast has become interruptible or uninterruptible.
 
 	* self - the Castbar widget
 	* unit - unit for which the update has been triggered (string)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -85,6 +85,7 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
     Castbar.SafeZone = SafeZone
     self.Castbar = Castbar
 --]]
+
 local _, ns = ...
 local oUF = ns.oUF
 
@@ -169,7 +170,7 @@ local function CastStart(self, event, unit)
 	Called after the element has been updated upon a spell cast start.
 
 	* self - the Castbar widget
-	* unit - unit for which the update has been triggered (string)
+	* unit - the unit for which the update has been triggered (string)
 	--]]
 	if(element.PostCastStart) then
 		element:PostCastStart(unit)
@@ -195,7 +196,7 @@ local function CastStop(self, event, unit, castID, spellID)
 	Called after the element has been updated when a spell cast has stopped.
 
 	* self    - the Castbar widget
-	* unit    - unit for which the update has been triggered (string)
+	* unit    - the unit for which the update has been triggered (string)
 	* spellID - the ID of the spell (number)
 	--]]
 	if(element.PostCastStop) then
@@ -249,7 +250,7 @@ local function CastDelay(self, event, unit, castID, spellID)
 	Called after the element has been updated when a spell cast has been delayed.
 
 	* self - the Castbar widget
-	* unit - unit that the update has been triggered (string)
+	* unit - the unit that the update has been triggered (string)
 	--]]
 	if(element.PostCastDelay) then
 		return element:PostCastDelay(unit)
@@ -279,7 +280,7 @@ local function CastFail(self, event, unit, castID, spellID)
 	Called after the element has been updated upon a failed spell cast.
 
 	* self    - the Castbar widget
-	* unit    - unit for which the update has been triggered (string)
+	* unit    - the unit for which the update has been triggered (string)
 	* spellID - the ID of the spell (number)
 	--]]
 	if(element.PostCastFail) then
@@ -301,7 +302,7 @@ local function CastInterruptible(self, event, unit)
 	Called after the element has been updated when a spell cast has become interruptible or uninterruptible.
 
 	* self - the Castbar widget
-	* unit - unit for which the update has been triggered (string)
+	* unit - the unit for which the update has been triggered (string)
 	--]]
 	if(element.PostCastInterruptible) then
 		return element:PostCastInterruptible(unit)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -101,7 +101,7 @@ local function resetAttributes(self)
 end
 
 local function CastStart(self, event, unit)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
+	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
 
@@ -186,7 +186,7 @@ local function CastStart(self, event, unit)
 end
 
 local function CastStop(self, event, unit, castID, spellID)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
+	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
 
@@ -210,7 +210,7 @@ local function CastStop(self, event, unit, castID, spellID)
 end
 
 local function CastDelay(self, event, unit, castID, spellID)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
+	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
 	if(not element:IsShown() or element.castID ~= castID or element.spellID ~= spellID) then
@@ -263,7 +263,7 @@ local function CastDelay(self, event, unit, castID, spellID)
 end
 
 local function CastFail(self, event, unit, castID, spellID)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
+	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
 	if(not element:IsShown() or element.castID ~= castID or element.spellID ~= spellID) then
@@ -293,7 +293,7 @@ local function CastFail(self, event, unit, castID, spellID)
 end
 
 local function CastInterruptible(self, event, unit)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
+	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
 	if(not element:IsShown()) then return end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -394,11 +394,8 @@ local function Enable(self, unit)
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 
 		if(self.unit == 'player') then
-			CastingBarFrame:UnregisterAllEvents()
-			CastingBarFrame:Hide()
-
-			PetCastingBarFrame:UnregisterAllEvents()
-			PetCastingBarFrame:Hide()
+			CastingBarFrame_SetUnit(CastingBarFrame, nil)
+			CastingBarFrame_SetUnit(PetCastingBarFrame, nil)
 		end
 
 		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -204,7 +204,7 @@ local function CastStop(self, event, unit, castID, spellID)
 	end
 end
 
-local function CastDelay(self, event, unit, castID, spellID)
+local function CastUpdate(self, event, unit, castID, spellID)
 	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
@@ -246,14 +246,14 @@ local function CastDelay(self, event, unit, castID, spellID)
 	element:SetMinMaxValues(0, element.max)
 	element:SetValue(element.duration)
 
-	--[[ Callback: Castbar:PostCastDelay(unit)
+	--[[ Callback: Castbar:PostCastUpdate(unit)
 	Called after the element has been updated when a spell cast has been delayed.
 
 	* self - the Castbar widget
 	* unit - the unit that the update has been triggered (string)
 	--]]
-	if(element.PostCastDelay) then
-		return element:PostCastDelay(unit)
+	if(element.PostCastUpdate) then
+		return element:PostCastUpdate(unit)
 	end
 end
 
@@ -385,8 +385,8 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_START', CastStart)
 		self:RegisterEvent('UNIT_SPELLCAST_STOP', CastStop)
 		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
-		self:RegisterEvent('UNIT_SPELLCAST_DELAYED', CastDelay)
-		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
+		self:RegisterEvent('UNIT_SPELLCAST_DELAYED', CastUpdate)
+		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastUpdate)
 		self:RegisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
@@ -436,8 +436,8 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_START', CastStart)
 		self:UnregisterEvent('UNIT_SPELLCAST_STOP', CastStop)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
-		self:UnregisterEvent('UNIT_SPELLCAST_DELAYED', CastDelay)
-		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
+		self:UnregisterEvent('UNIT_SPELLCAST_DELAYED', CastUpdate)
+		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastUpdate)
 		self:UnregisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -258,20 +258,20 @@ local function CastDelay(self, event, unit, castID, spellID)
 	end
 end
 
-local function UNIT_SPELLCAST_FAILED(self, event, unit, castID)
+local function CastFail(self, event, unit, castID, spellID)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local element = self.Castbar
-	if(element.castID ~= castID) then
+	if(not element:IsShown() or element.castID ~= castID or element.spellID ~= spellID) then
 		return
 	end
 
-	local text = element.Text
-	if(text) then
-		text:SetText(FAILED)
+	if(element.Text) then
+		element.Text:SetText(event == 'UNIT_SPELLCAST_FAILED' and FAILED or INTERRUPTED)
 	end
 
 	element.casting = nil
+	element.channeling = nil
 	element.notInterruptible = nil
 	element.holdTime = element.timeToHold or 0
 
@@ -283,34 +283,6 @@ local function UNIT_SPELLCAST_FAILED(self, event, unit, castID)
 	--]]
 	if(element.PostCastFailed) then
 		return element:PostCastFailed(unit)
-	end
-end
-
-local function UNIT_SPELLCAST_INTERRUPTED(self, event, unit, castID)
-	if(self.unit ~= unit and self.realUnit ~= unit) then return end
-
-	local element = self.Castbar
-	if(element.castID ~= castID) then
-		return
-	end
-
-	local text = element.Text
-	if(text) then
-		text:SetText(INTERRUPTED)
-	end
-
-	element.casting = nil
-	element.channeling = nil
-	element.holdTime = element.timeToHold or 0
-
-	--[[ Callback: Castbar:PostCastInterrupted(unit)
-	Called after the element has been updated upon an interrupted spell cast.
-
-	* self - the Castbar widget
-	* unit - unit for which the update has been triggered (string)
-	--]]
-	if(element.PostCastInterrupted) then
-		return element:PostCastInterrupted(unit)
 	end
 end
 
@@ -471,9 +443,9 @@ local function Enable(self, unit)
 			self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
 			self:RegisterEvent('UNIT_SPELLCAST_DELAYED', CastDelay)
 			self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
+			self:RegisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
+			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 
-			self:RegisterEvent('UNIT_SPELLCAST_FAILED', UNIT_SPELLCAST_FAILED)
-			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', UNIT_SPELLCAST_INTERRUPTED)
 			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', UNIT_SPELLCAST_INTERRUPTIBLE)
 			self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
 		end
@@ -528,9 +500,9 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
 		self:UnregisterEvent('UNIT_SPELLCAST_DELAYED', CastDelay)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
+		self:UnregisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
+		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 
-		self:UnregisterEvent('UNIT_SPELLCAST_FAILED', UNIT_SPELLCAST_FAILED)
-		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTED', UNIT_SPELLCAST_INTERRUPTED)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', UNIT_SPELLCAST_INTERRUPTIBLE)
 		self:UnregisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', UNIT_SPELLCAST_NOT_INTERRUPTIBLE)
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -52,7 +52,7 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
     local Spark = Castbar:CreateTexture(nil, 'OVERLAY')
     Spark:SetSize(20, 20)
     Spark:SetBlendMode('ADD')
-    Spark:SetPoint("CENTER", Castbar:GetStatusBarTexture(), "RIGHT", 0, 0)
+    Spark:SetPoint('CENTER', Castbar:GetStatusBarTexture(), 'RIGHT', 0, 0)
 
     -- Add a timer
     local Time = Castbar:CreateFontString(nil, 'OVERLAY', 'GameFontNormalSmall')
@@ -444,7 +444,7 @@ local function Disable(self)
 		element:SetScript('OnUpdate', nil)
 
 		if(self.unit == 'player') then
-			CastingBarFrame_OnLoad(CastingBarFrame, "player", true, false)
+			CastingBarFrame_OnLoad(CastingBarFrame, 'player', true, false)
 			PetCastingBarFrame_OnLoad(PetCastingBarFrame)
 		end
 	end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -88,11 +88,6 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 local _, ns = ...
 local oUF = ns.oUF
 
-local GetNetStats = GetNetStats
-local GetTime = GetTime
-local UnitCastingInfo = UnitCastingInfo
-local UnitChannelInfo = UnitChannelInfo
-
 local function resetAttributes(self)
 	self.castID = nil
 	self.casting = nil

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -179,31 +179,6 @@ local function CastStart(self, event, unit)
 	element:Show()
 end
 
-local function CastStop(self, event, unit, castID, spellID)
-	if(self.unit ~= unit) then return end
-
-	local element = self.Castbar
-
-	-- Channeled spells for some reason don't have castIDs
-	if(element.castID ~= castID or element.spellID ~= spellID) then return end
-
-	if(element.Spark) then element.Spark:Hide() end
-
-	resetAttributes(element)
-	element:SetValue(element.max)
-
-	--[[ Callback: Castbar:PostCastStop(unit, spellID)
-	Called after the element has been updated when a spell cast has stopped.
-
-	* self    - the Castbar widget
-	* unit    - the unit for which the update has been triggered (string)
-	* spellID - the ID of the spell (number)
-	--]]
-	if(element.PostCastStop) then
-		return element:PostCastStop(unit, spellID)
-	end
-end
-
 local function CastUpdate(self, event, unit, castID, spellID)
 	if(self.unit ~= unit) then return end
 
@@ -254,6 +229,31 @@ local function CastUpdate(self, event, unit, castID, spellID)
 	--]]
 	if(element.PostCastUpdate) then
 		return element:PostCastUpdate(unit)
+	end
+end
+
+local function CastStop(self, event, unit, castID, spellID)
+	if(self.unit ~= unit) then return end
+
+	local element = self.Castbar
+
+	-- Channeled spells for some reason don't have castIDs
+	if(element.castID ~= castID or element.spellID ~= spellID) then return end
+
+	if(element.Spark) then element.Spark:Hide() end
+
+	resetAttributes(element)
+	element:SetValue(element.max)
+
+	--[[ Callback: Castbar:PostCastStop(unit, spellID)
+	Called after the element has been updated when a spell cast has stopped.
+
+	* self    - the Castbar widget
+	* unit    - the unit for which the update has been triggered (string)
+	* spellID - the ID of the spell (number)
+	--]]
+	if(element.PostCastStop) then
+		return element:PostCastStop(unit, spellID)
 	end
 end
 
@@ -434,10 +434,10 @@ local function Disable(self)
 
 		self:UnregisterEvent('UNIT_SPELLCAST_START', CastStart)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_START', CastStart)
-		self:UnregisterEvent('UNIT_SPELLCAST_STOP', CastStop)
-		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
 		self:UnregisterEvent('UNIT_SPELLCAST_DELAYED', CastUpdate)
 		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastUpdate)
+		self:UnregisterEvent('UNIT_SPELLCAST_STOP', CastStop)
+		self:UnregisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
 		self:UnregisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
 		self:UnregisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -2,7 +2,6 @@
 # Element: Castbar
 
 Handles the visibility and updating of spell castbars.
-Based upon oUF_Castbar by starlon.
 
 ## Widget
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -149,6 +149,7 @@ local function CastStart(self, event, unit, castID, spellID)
 
 	if(element.Icon) then element.Icon:SetTexture(texture or [[Interface\ICONS\INV_Misc_QuestionMark]]) end
 	if(element.Shield) then element.Shield:SetShown(notInterruptible) end
+	if(element.Spark) then element.Spark:Show() end
 	if(element.Text) then element.Text:SetText(name) end
 	if(element.Time) then element.Time:SetText() end
 
@@ -189,9 +190,13 @@ local function CastStop(self, event, unit, castID, spellID)
 	-- Channeled spells for some reason don't have castIDs
 	if(element.castID ~= castID or element.spellID ~= spellID) then return end
 
+	if(element.Spark) then element.Spark:Hide() end
+
 	element.casting = nil
 	element.channeling = nil
 	element.notInterruptible = nil
+
+	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastStop(unit)
 	Called after the element has been updated when a spell cast has finished.
@@ -270,10 +275,14 @@ local function CastFail(self, event, unit, castID, spellID)
 		element.Text:SetText(event == 'UNIT_SPELLCAST_FAILED' and FAILED or INTERRUPTED)
 	end
 
+	if(element.Spark) then element.Spark:Hide() end
+
 	element.casting = nil
 	element.channeling = nil
 	element.notInterruptible = nil
 	element.holdTime = element.timeToHold or 0
+
+	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastFailed(unit)
 	Called after the element has been updated upon a failed spell cast.

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -252,15 +252,14 @@ local function CastDelay(self, event, unit, castID, spellID)
 	element:SetMinMaxValues(0, element.max)
 	element:SetValue(element.duration)
 
-	--[[ Callback: Castbar:PostCastDelayed(unit, name)
+	--[[ Callback: Castbar:PostCastDelay(unit)
 	Called after the element has been updated when a spell cast has been delayed.
 
 	* self - the Castbar widget
 	* unit - unit that the update has been triggered (string)
-	* name - name of the delayed spell (string)
 	--]]
-	if(element.PostCastDelayed) then
-		return element:PostCastDelayed(unit, name)
+	if(element.PostCastDelay) then
+		return element:PostCastDelay(unit)
 	end
 end
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -104,7 +104,7 @@ local function updateSafeZone(self)
 	safeZone:SetWidth(width * safeZoneRatio)
 end
 
-local function CastStart(self, event, unit, castID, spellID)
+local function CastStart(self, event, unit)
 	if(self.unit ~= unit and self.realUnit ~= unit) then return end
 
 	local element = self.Castbar
@@ -116,14 +116,15 @@ local function CastStart(self, event, unit, castID, spellID)
 		  and the player is shown in the pet frame, see PetCastingBarFrame_OnEvent
 	]]
 
-	local name, texture, startTime, endTime, isTradeSkill, notInterruptible, _
-	if(event == 'UNIT_SPELLCAST_START') then
-		name, _, texture, startTime, endTime, isTradeSkill, _, notInterruptible = UnitCastingInfo(unit)
-	else
-		name, _, texture, startTime, endTime, isTradeSkill, notInterruptible = UnitChannelInfo(unit)
-	end
+	local name, _, texture, startTime, endTime, isTradeSkill, castID, notInterruptible, spellID = UnitCastingInfo(unit)
+	event = 'UNIT_SPELLCAST_START'
 
-	if(not name) then return end
+	if(not name) then
+		name, _, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID = UnitChannelInfo(unit)
+		event = 'UNIT_SPELLCAST_CHANNEL_START'
+
+		if(not name) then return end
+	end
 
 	endTime = endTime / 1e3
 	startTime = startTime / 1e3

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -22,8 +22,9 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 
 ## Options
 
-.timeToHold - indicates for how many seconds the castbar should be visible after a _FAILED or _INTERRUPTED
-              event. Defaults to 0 (number)
+.timeToHold      - indicates for how many seconds the castbar should be visible after a _FAILED or _INTERRUPTED
+                   event. Defaults to 0 (number)
+.hideTradeSkills - makes the element ignore casts related to crafted professions (boolean)
 
 ## Attributes
 
@@ -105,26 +106,18 @@ local function CastStart(self, event, unit)
 
 	local element = self.Castbar
 
-	--[[ REVAMP NOTES:
-		- It's possible not to display the castbar for trade skills in the default UI
-		  via the .showTradeSkills attribute
-		- The pet castbar should be hidden while the player is possessing something,
-		  and the player is shown in the pet frame, see PetCastingBarFrame_OnEvent
-	]]
-
 	local name, _, texture, startTime, endTime, isTradeSkill, castID, notInterruptible, spellID = UnitCastingInfo(unit)
 	event = 'UNIT_SPELLCAST_START'
-
 	if(not name) then
 		name, _, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID = UnitChannelInfo(unit)
 		event = 'UNIT_SPELLCAST_CHANNEL_START'
+	end
 
-		if(not name) then
-			resetAttributes(element)
-			element:Hide()
+	if(not name or (isTradeSkill and element.hideTradeSkills)) then
+		resetAttributes(element)
+		element:Hide()
 
-			return
-		end
+		return
 	end
 
 	endTime = endTime / 1e3

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -413,22 +413,20 @@ end
 
 local function Enable(self, unit)
 	local element = self.Castbar
-	if(element) then
+	if(element and unit and not unit:match('%wtarget$')) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
 
-		if(not (unit and unit:match'%wtarget$')) then
-			self:RegisterEvent('UNIT_SPELLCAST_START', CastStart)
-			self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_START', CastStart)
-			self:RegisterEvent('UNIT_SPELLCAST_STOP', CastStop)
-			self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
-			self:RegisterEvent('UNIT_SPELLCAST_DELAYED', CastDelay)
-			self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
-			self:RegisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
-			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
-			self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
-			self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
-		end
+		self:RegisterEvent('UNIT_SPELLCAST_START', CastStart)
+		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_START', CastStart)
+		self:RegisterEvent('UNIT_SPELLCAST_STOP', CastStop)
+		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_STOP', CastStop)
+		self:RegisterEvent('UNIT_SPELLCAST_DELAYED', CastDelay)
+		self:RegisterEvent('UNIT_SPELLCAST_CHANNEL_UPDATE', CastDelay)
+		self:RegisterEvent('UNIT_SPELLCAST_FAILED', CastFail)
+		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTED', CastFail)
+		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
+		self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 
 		element.holdTime = 0
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -242,10 +242,7 @@ local function CastStop(self, event, unit, castID, spellID)
 		return
 	end
 
-	if(element.Spark) then element.Spark:Hide() end
-
 	resetAttributes(element)
-	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastStop(unit, spellID)
 	Called after the element has been updated when a spell cast has stopped.

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -134,8 +134,6 @@ local function CastStart(self, event, unit)
 	element.holdTime = 0
 	element.castID = castID
 	element.spellID = spellID
-	element.isHorizontal = element:GetOrientation() == 'HORIZONTAL'
-	element.isReversed = element:GetReverseFill()
 
 	if(element.casting) then
 		element.duration = GetTime() - startTime
@@ -154,16 +152,16 @@ local function CastStart(self, event, unit)
 
 	local safeZone = element.SafeZone
 	if(safeZone) then
-		local isHoriz = element.isHorizontal
+		local isHoriz = element:GetOrientation() == 'HORIZONTAL'
 
 		safeZone:ClearAllPoints()
 		safeZone:SetPoint(isHoriz and 'TOP' or 'LEFT')
 		safeZone:SetPoint(isHoriz and 'BOTTOM' or 'RIGHT')
 
 		if(element.casting) then
-			safeZone:SetPoint(element.isReversed and (isHoriz and 'LEFT' or 'BOTTOM') or (isHoriz and 'RIGHT' or 'TOP'))
+			safeZone:SetPoint(element:GetReverseFill() and (isHoriz and 'LEFT' or 'BOTTOM') or (isHoriz and 'RIGHT' or 'TOP'))
 		else
-			safeZone:SetPoint(element.isReversed and (isHoriz and 'RIGHT' or 'TOP') or (isHoriz and 'LEFT' or 'BOTTOM'))
+			safeZone:SetPoint(element:GetReverseFill() and (isHoriz and 'RIGHT' or 'TOP') or (isHoriz and 'LEFT' or 'BOTTOM'))
 		end
 
 		local ratio = (select(4, GetNetStats()) / 1e3) / element.max

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -115,8 +115,8 @@ local function CastStart(self, event, unit)
 		return
 	end
 
-	endTime = endTime / 1e3
-	startTime = startTime / 1e3
+	endTime = endTime / 1000
+	startTime = startTime / 1000
 
 	element.max = endTime - startTime
 	element.startTime = startTime
@@ -157,7 +157,7 @@ local function CastStart(self, event, unit)
 			safeZone:SetPoint(element:GetReverseFill() and (isHoriz and 'RIGHT' or 'TOP') or (isHoriz and 'LEFT' or 'BOTTOM'))
 		end
 
-		local ratio = (select(4, GetNetStats()) / 1e3) / element.max
+		local ratio = (select(4, GetNetStats()) / 1000) / element.max
 		if(ratio > 1) then
 			ratio = 1
 		end
@@ -219,8 +219,8 @@ local function CastDelay(self, event, unit, castID, spellID)
 
 	if(not name) then return end
 
-	endTime = endTime / 1e3
-	startTime = startTime / 1e3
+	endTime = endTime / 1000
+	startTime = startTime / 1000
 
 	local delta
 	if(element.casting) then

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -222,7 +222,7 @@ local function CastUpdate(self, event, unit, castID, spellID)
 	element:SetValue(element.duration)
 
 	--[[ Callback: Castbar:PostCastUpdate(unit)
-	Called after the element has been updated when a spell cast has been delayed.
+	Called after the element has been updated when a spell cast has been updated.
 
 	* self - the Castbar widget
 	* unit - the unit that the update has been triggered (string)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -165,7 +165,7 @@ local function CastStart(self, event, unit)
 			ratio = 1
 		end
 
-		safeZone:SetWidth(element[isHoriz and 'GetWidth' or 'GetHeight'](element) * ratio)
+		safeZone[isHoriz and 'SetWidth' or 'SetHeight'](safeZone, element[isHoriz and 'GetWidth' or 'GetHeight'](element) * ratio)
 	end
 
 	--[[ Callback: Castbar:PostCastStart(unit)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -128,7 +128,6 @@ local function CastStart(self, event, unit, castID, spellID)
 	endTime = endTime / 1e3
 	startTime = startTime / 1e3
 
-	element.duration = GetTime() - startTime
 	element.max = endTime - startTime
 	element.delay = 0
 	element.casting = event == 'UNIT_SPELLCAST_START'
@@ -137,6 +136,12 @@ local function CastStart(self, event, unit, castID, spellID)
 	element.holdTime = 0
 	element.castID = castID
 	element.spellID = spellID
+
+	if(element.casting) then
+		element.duration = GetTime() - startTime
+	else
+		element.duration = endTime - GetTime()
+	end
 
 	element:SetMinMaxValues(0, element.max)
 	element:SetValue(0)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -282,14 +282,14 @@ local function CastFail(self, event, unit, castID, spellID)
 	resetAttributes(element)
 	element:SetValue(element.max)
 
-	--[[ Callback: Castbar:PostCastFailed(unit)
+	--[[ Callback: Castbar:PostCastFail(unit)
 	Called after the element has been updated upon a failed spell cast.
 
 	* self - the Castbar widget
 	* unit - unit for which the update has been triggered (string)
 	--]]
-	if(element.PostCastFailed) then
-		return element:PostCastFailed(unit)
+	if(element.PostCastFail) then
+		return element:PostCastFail(unit)
 	end
 end
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -237,9 +237,9 @@ local function CastStop(self, event, unit, castID, spellID)
 	if(self.unit ~= unit) then return end
 
 	local element = self.Castbar
-
-	-- Channeled spells for some reason don't have castIDs
-	if(element.castID ~= castID or element.spellID ~= spellID) then return end
+	if(not element:IsShown() or element.castID ~= castID or element.spellID ~= spellID) then
+		return
+	end
 
 	if(element.Spark) then element.Spark:Hide() end
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -367,8 +367,8 @@ local function onUpdate(self, elapsed)
 	end
 end
 
-local function Update(self, ...)
-	CastStart(self, ...)
+local function Update(...)
+	CastStart(...)
 end
 
 local function ForceUpdate(element)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -432,7 +432,6 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_SPELLCAST_INTERRUPTIBLE', CastInterruptible)
 		self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 
-		element.holdTime = 0
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 
 		if(self.unit == 'player') then

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -89,7 +89,7 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 local _, ns = ...
 local oUF = ns.oUF
 
-local DEFAULT_ICON = [[Interface\ICONS\INV_Misc_QuestionMark]]
+local FALLBACK_ICON = 136243 -- Interface\ICONS\Trade_Engineering
 
 local function resetAttributes(self)
 	self.castID = nil
@@ -140,7 +140,7 @@ local function CastStart(self, event, unit)
 	element:SetMinMaxValues(0, element.max)
 	element:SetValue(element.duration)
 
-	if(element.Icon) then element.Icon:SetTexture(texture or DEFAULT_ICON) end
+	if(element.Icon) then element.Icon:SetTexture(texture or FALLBACK_ICON) end
 	if(element.Shield) then element.Shield:SetShown(notInterruptible) end
 	if(element.Spark) then element.Spark:Show() end
 	if(element.Text) then element.Text:SetText(name) end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -169,7 +169,7 @@ local function CastStart(self, event, unit)
 	end
 
 	--[[ Callback: Castbar:PostCastStart(unit)
-	Called after the element has been updated upon a spell cast start.
+	Called after the element has been updated upon a spell cast or channel start.
 
 	* self - the Castbar widget
 	* unit - the unit for which the update has been triggered (string)
@@ -224,7 +224,7 @@ local function CastUpdate(self, event, unit, castID, spellID)
 	element:SetValue(element.duration)
 
 	--[[ Callback: Castbar:PostCastUpdate(unit)
-	Called after the element has been updated when a spell cast has been updated.
+	Called after the element has been updated when a spell cast or channel has been updated.
 
 	* self - the Castbar widget
 	* unit - the unit that the update has been triggered (string)
@@ -245,7 +245,7 @@ local function CastStop(self, event, unit, castID, spellID)
 	resetAttributes(element)
 
 	--[[ Callback: Castbar:PostCastStop(unit, spellID)
-	Called after the element has been updated when a spell cast has stopped.
+	Called after the element has been updated when a spell cast or channel has stopped.
 
 	* self    - the Castbar widget
 	* unit    - the unit for which the update has been triggered (string)
@@ -276,7 +276,7 @@ local function CastFail(self, event, unit, castID, spellID)
 	element:SetValue(element.max)
 
 	--[[ Callback: Castbar:PostCastFail(unit, spellID)
-	Called after the element has been updated upon a failed spell cast.
+	Called after the element has been updated upon a failed or interrupted spell cast.
 
 	* self    - the Castbar widget
 	* unit    - the unit for which the update has been triggered (string)


### PR DESCRIPTION
The purpose of this PR is to revamp the castbar element.

It's been largely untouched for almost a decade, there's a number of features missing, and the amount of code duplication is mind-boggling.

The first goal is to get rid of excessive code duplication by merging events' handlers like so:

- `UNIT_SPELLCAST_START` + `UNIT_SPELLCAST_CHANNEL_START` => `CastStart`
- `UNIT_SPELLCAST_DELAYED` + `UNIT_SPELLCAST_CHANNEL_UPDATE` => `CastUpdate`
- `UNIT_SPELLCAST_STOP` + `UNIT_SPELLCAST_CHANNEL_STOP` => `CastStop`
- `UNIT_SPELLCAST_INTERRUPTED` + `UNIT_SPELLCAST_FAILED` => `CastFail`
- `UNIT_SPELLCAST_NOT_INTERRUPTIBLE` + `UNIT_SPELLCAST_INTERRUPTIBLE` => `CastInterruptible`

Changes:

Because a good half of events' handlers was removed, some of callbacks were removed as well, others were renamed and had their args changed, so the list of new callbacks looks like this:

- `element:PostCastStart(unit, name)` + `element:PostChannelStart(unit, name)`  
  => `element:PostCastStart(unit)`

- `element:PostCastDelayed(unit, name)` + `element:PostChannelUpdate(unit, name)`  
  => `element:PostCastUpdate(unit)`

- `element:PostCastStop(unit)` + `element:PostChannelStop(unit)`
  => `element:PostCastStop(unit, spellID)`

- `element:PostCastFailed(unit)` + `element:PostCastInterrupted(unit)`  
  => `element:PostCastFail(unit, spellID)`

- `element:PostCastNotInterruptible(unit)` + `element:PostCastInterruptible(unit)`  
  => `element:PostCastInterruptible(unit)`

Added `spellID` to `PostCastStop` and `PostCastFail` since they may be useful to some, but at that point they're no longer available via `element.spellID`.

From now on positioning of the `.Spark` sub-widget should be handled by the layout, for instance:
```lua
Spark:SetPoint("CENTER", Castbar:GetStatusBarTexture(), "RIGHT", 0, 0)
```

`.SafeZone` now properly supports vertically-oriented cast bars.

It's no longer possible to create castbars for targettarget, focustarget, and other similar units since their respective unit frames aren't driven by events, but rely on the `OnUpdate` script.

Added the `.hideTradeSkills` option, the name is self-explanatory, added it since the same option is present in the default UI.