### PR TITLE
core: register the vehicle events as unitless on the pet frame

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -272,8 +272,8 @@ local function initObject(unit, style, styleFunc, header, ...)
 		end
 
 		if(not (suffix == 'target' or objectUnit and objectUnit:match('target'))) then
-			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit)
-			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit)
+			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit, unit == 'pet')
+			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit, unit == 'pet')
 			object:RegisterEvent('UNIT_EXITING_VEHICLE', updateActiveUnit)
 
 			-- We don't need to register UNIT_PET for the player unit. We register it


### PR DESCRIPTION
UNIT_EXITING_VEHICLE is probably not needed here (there will be either the same or more info available at UNIT_EXITED_VEHICLE).