### PR TITLE
core: Update the event system

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -41,8 +41,15 @@ function Private.UpdateUnits(frame, unit, realUnit)
 	end
 end
 
+-- Used for updating active units
+local controlEvents = {
+	UNIT_ENTERED_VEHICLE = true,
+	UNIT_EXITED_VEHICLE = true,
+	UNIT_PET = true,
+}
+
 local function onEvent(self, event, ...)
-	if(self:IsVisible()) then
+	if(self:IsVisible() or controlEvents[event]) then
 		return self[event](self, event, ...)
 	end
 end

--- a/events.lua
+++ b/events.lua
@@ -137,7 +137,7 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 			local unit1, unit2 = self.unit
 			if(unit1 and validateUnit(unit1)) then
 				if(controlEvents[event]) then
-					unit2 = controlEvents[event]
+					unit2 = controlEvents[event][unit1]
 				end
 
 				registerUnitEvent(self, event, unit1, unit2 or '')

--- a/events.lua
+++ b/events.lua
@@ -19,7 +19,7 @@ function Private.UpdateUnits(frame, unit, realUnit)
 	end
 
 	if(frame.unit ~= unit or frame.realUnit ~= realUnit) then
-		if(frame.unitEvents) then
+		if(frame.unitEvents and validateUnit(unit)) then
 			for event in next, frame.unitEvents do
 				local registered, unit1 = isEventRegistered(frame, event)
 				-- unit event registration for header units is postponed until

--- a/events.lua
+++ b/events.lua
@@ -14,7 +14,7 @@ local unregisterEvent = frame_metatable.__index.UnregisterEvent
 local isEventRegistered = frame_metatable.__index.IsEventRegistered
 
 -- Used for updating active units
-local controlEvents = {
+local secondaryUnits = {
 	UNIT_ENTERED_VEHICLE = {
 		pet = 'player',
 	},
@@ -36,8 +36,8 @@ function Private.UpdateUnits(frame, unit, realUnit)
 	if(frame.unit ~= unit or frame.realUnit ~= realUnit) then
 		if(frame.unitEvents and validateUnit(unit)) then
 			for event in next, frame.unitEvents do
-				if(not realUnit and controlEvents[event]) then
-					realUnit = controlEvents[event][unit]
+				if(not realUnit and secondaryUnits[event]) then
+					realUnit = secondaryUnits[event][unit]
 					resetRealUnit = true
 				end
 
@@ -136,8 +136,8 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 			-- units in case we don't have a valid unit yet
 			local unit1, unit2 = self.unit
 			if(unit1 and validateUnit(unit1)) then
-				if(controlEvents[event]) then
-					unit2 = controlEvents[event][unit1]
+				if(secondaryUnits[event]) then
+					unit2 = secondaryUnits[event][unit1]
 				end
 
 				registerUnitEvent(self, event, unit1, unit2 or '')

--- a/events.lua
+++ b/events.lua
@@ -13,7 +13,8 @@ local registerUnitEvent = frame_metatable.__index.RegisterUnitEvent
 local unregisterEvent = frame_metatable.__index.UnregisterEvent
 local isEventRegistered = frame_metatable.__index.IsEventRegistered
 
--- Used for updating active units
+-- to update unit frames correctly, some events need to be registered for
+-- an addition unit
 local secondaryUnits = {
 	UNIT_ENTERED_VEHICLE = {
 		pet = 'player',
@@ -34,6 +35,8 @@ function Private.UpdateUnits(frame, unit, realUnit)
 	local resetRealUnit = false
 
 	if(frame.unit ~= unit or frame.realUnit ~= realUnit) then
+		-- don't let invalid units in, otherwise unit events will end up being
+		-- registered as unitless
 		if(frame.unitEvents and validateUnit(unit)) then
 			for event in next, frame.unitEvents do
 				if(not realUnit and secondaryUnits[event]) then
@@ -42,13 +45,12 @@ function Private.UpdateUnits(frame, unit, realUnit)
 				end
 
 				local registered, unit1, unit2 = isEventRegistered(frame, event)
-				-- unit event registration for header units is postponed until
-				-- the frame units are known
 				-- we don't want to re-register unitless/shared events in case
 				-- someone added them by hand to the unitEvents table
 				if(not registered or unit1 and (unit1 ~= unit or unit2 ~= realUnit)) then
 					-- BUG: passing explicit nil units to RegisterUnitEvent
-					-- makes it silently fall back to RegisterEvent
+					-- makes it silently fall back to RegisterEvent, using ''
+					-- instead of explicit nils doesn't cause this behaviour
 					registerUnitEvent(frame, event, unit, realUnit or '')
 				end
 

--- a/events.lua
+++ b/events.lua
@@ -64,6 +64,7 @@ function Private.UpdateUnits(frame, unit, realUnit)
 		frame.unit = unit
 		frame.realUnit = realUnit
 		frame.id = unit:match('^.-(%d+)')
+
 		return true
 	end
 end
@@ -165,6 +166,7 @@ function frame_metatable.__index:UnregisterEvent(event, func)
 		for k, infunc in next, curev do
 			if(infunc == func) then
 				curev[k] = nil
+
 				break
 			end
 		end
@@ -179,6 +181,7 @@ function frame_metatable.__index:UnregisterEvent(event, func)
 		if(self.unitEvents) then
 			self.unitEvents[event] = nil
 		end
+
 		unregisterEvent(self, event)
 	end
 end

--- a/events.lua
+++ b/events.lua
@@ -32,12 +32,12 @@ function Private.UpdateUnits(frame, unit, realUnit)
 		realUnit = nil
 	end
 
-	local resetRealUnit = false
-
 	if(frame.unit ~= unit or frame.realUnit ~= realUnit) then
 		-- don't let invalid units in, otherwise unit events will end up being
 		-- registered as unitless
 		if(frame.unitEvents and validateUnit(unit)) then
+			local resetRealUnit = false
+
 			for event in next, frame.unitEvents do
 				if(not realUnit and secondaryUnits[event]) then
 					realUnit = secondaryUnits[event][unit]

--- a/events.lua
+++ b/events.lua
@@ -14,7 +14,7 @@ local unregisterEvent = frame_metatable.__index.UnregisterEvent
 local isEventRegistered = frame_metatable.__index.IsEventRegistered
 
 -- to update unit frames correctly, some events need to be registered for
--- an addition unit
+-- a specific combination of primary and secondary units
 local secondaryUnits = {
 	UNIT_ENTERED_VEHICLE = {
 		pet = 'player',

--- a/events.lua
+++ b/events.lua
@@ -46,7 +46,7 @@ function Private.UpdateUnits(frame, unit, realUnit)
 				-- the frame units are known
 				-- we don't want to re-register unitless/shared events in case
 				-- someone added them by hand to the unitEvents table
-				if(registered and unit1 and (unit1 ~= unit or unit2 ~= realUnit) or not registered) then
+				if(not registered or unit1 and (unit1 ~= unit or unit2 ~= realUnit)) then
 					-- BUG: passing explicit nil units to RegisterUnitEvent
 					-- makes it silently fall back to RegisterEvent
 					registerUnitEvent(frame, event, unit, realUnit or '')

--- a/events.lua
+++ b/events.lua
@@ -67,7 +67,7 @@ function Private.UpdateUnits(frame, unit, realUnit)
 end
 
 local function onEvent(self, event, ...)
-	if(self:IsVisible() or controlEvents[event]) then
+	if(self:IsVisible()) then
 		return self[event](self, event, ...)
 	end
 end

--- a/ouf.lua
+++ b/ouf.lua
@@ -250,7 +250,7 @@ end
 
 local function updateRaid(self, event)
 	local unitGUID = UnitGUID(self.unit)
-	if unitGUID and unitGUID ~= self.unitGUID then
+	if(unitGUID and unitGUID ~= self.unitGUID) then
 		self.unitGUID = unitGUID
 
 		self:UpdateAllElements(event)

--- a/ouf.lua
+++ b/ouf.lua
@@ -58,11 +58,11 @@ local function updateActiveUnit(self, event, unit)
 		modUnit = 'vehicle'
 	end
 
-	-- Change the active unit and, if possible, run a full update.
+	if(not UnitExists(modUnit)) then return end
+
+	-- Change the active unit and run a full update.
 	if(Private.UpdateUnits(self, modUnit, realUnit)) then
-		if(UnitExists(modUnit)) then
-			self:UpdateAllElements('RefreshUnit')
-		end
+		self:UpdateAllElements('RefreshUnit')
 
 		return true
 	end

--- a/ouf.lua
+++ b/ouf.lua
@@ -271,7 +271,7 @@ local function initObject(unit, style, styleFunc, header, ...)
 			objectUnit = objectUnit .. suffix
 		end
 
-		if(not (header or suffix == 'target' or objectUnit and objectUnit:match('target'))) then
+		if(not (suffix == 'target' or objectUnit and objectUnit:match('target'))) then
 			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit)
 			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit)
 

--- a/ouf.lua
+++ b/ouf.lua
@@ -271,7 +271,7 @@ local function initObject(unit, style, styleFunc, header, ...)
 			objectUnit = objectUnit .. suffix
 		end
 
-		if(not (suffix == 'target' or objectUnit and objectUnit:match('target'))) then
+		if(not (header or suffix == 'target' or objectUnit and objectUnit:match('target'))) then
 			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit)
 			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit)
 			object:RegisterEvent('UNIT_EXITING_VEHICLE', updateActiveUnit)

--- a/ouf.lua
+++ b/ouf.lua
@@ -274,7 +274,6 @@ local function initObject(unit, style, styleFunc, header, ...)
 		if(not (header or suffix == 'target' or objectUnit and objectUnit:match('target'))) then
 			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit)
 			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit)
-			object:RegisterEvent('UNIT_EXITING_VEHICLE', updateActiveUnit)
 
 			-- We don't need to register UNIT_PET for the player unit. We register it
 			-- mainly because UNIT_EXITED_VEHICLE and UNIT_ENTERED_VEHICLE doesn't always

--- a/ouf.lua
+++ b/ouf.lua
@@ -248,6 +248,15 @@ local function updatePet(self, event, unit)
 	end
 end
 
+local function updateRaid(self, event)
+	local unitGUID = UnitGUID(self.unit)
+	if unitGUID and unitGUID ~= self.unitGUID then
+		self.unitGUID = unitGUID
+
+		self:UpdateAllElements(event)
+	end
+end
+
 local function initObject(unit, style, styleFunc, header, ...)
 	local num = select('#', ...)
 	for i = 1, num do
@@ -300,8 +309,9 @@ local function initObject(unit, style, styleFunc, header, ...)
 				oUF:HandleUnit(object)
 			end
 		else
-			-- Used to update frames when they change position in a group.
-			object:RegisterEvent('GROUP_ROSTER_UPDATE', object.UpdateAllElements, true)
+			-- update the frame when its prev unit is replaced with a new one
+			-- updateRaid relies on UnitGUID to detect the unit change
+			object:RegisterEvent('GROUP_ROSTER_UPDATE', updateRaid, true)
 
 			if(num > 1) then
 				if(object:GetParent() == header) then

--- a/ouf.lua
+++ b/ouf.lua
@@ -300,9 +300,6 @@ local function initObject(unit, style, styleFunc, header, ...)
 				oUF:HandleUnit(object)
 			end
 		else
-			-- Used to update frames when they change position in a group.
-			object:RegisterEvent('GROUP_ROSTER_UPDATE', object.UpdateAllElements, true)
-
 			if(num > 1) then
 				if(object:GetParent() == header) then
 					object.hasChildren = true

--- a/ouf.lua
+++ b/ouf.lua
@@ -58,11 +58,11 @@ local function updateActiveUnit(self, event, unit)
 		modUnit = 'vehicle'
 	end
 
-	if(not UnitExists(modUnit)) then return end
-
-	-- Change the active unit and run a full update.
-	if Private.UpdateUnits(self, modUnit, realUnit) then
-		self:UpdateAllElements('RefreshUnit')
+	-- Change the active unit and, if possible, run a full update.
+	if(Private.UpdateUnits(self, modUnit, realUnit)) then
+		if(UnitExists(modUnit)) then
+			self:UpdateAllElements('RefreshUnit')
+		end
 
 		return true
 	end

--- a/ouf.lua
+++ b/ouf.lua
@@ -300,6 +300,9 @@ local function initObject(unit, style, styleFunc, header, ...)
 				oUF:HandleUnit(object)
 			end
 		else
+			-- Used to update frames when they change position in a group.
+			object:RegisterEvent('GROUP_ROSTER_UPDATE', object.UpdateAllElements, true)
+
 			if(num > 1) then
 				if(object:GetParent() == header) then
 					object.hasChildren = true


### PR DESCRIPTION
The main purpose of this PR was to address an issue where oUF wasn't updating pet frame's unit while switching between `pet`, `player`, and `vehicle` units while having a real pet summoned. In this sense it addresses the same issue as #481 does, but in a different way.

It also addresses few other issues related to headers, e.g., unintentional registration of unit events as unitless, excessive `UpdateAllElements` calls on GRU, etc.