### PR TITLE
[8.1.5] Add .colorSelection option to health and power elements

### DIFF
--- a/colors.lua
+++ b/colors.lua
@@ -11,17 +11,13 @@ local colors = {
 		0, 1, 0
 	},
 	health = {49 / 255, 207 / 255, 37 / 255},
-	disconnected = {.6, .6, .6},
-	tapped = {.6, .6, .6},
+	disconnected = {0.6, 0.6, 0.6},
+	tapped = {0.6, 0.6, 0.6},
 	runes = {
 		{247 / 255, 65 / 255, 57 / 255}, -- blood
 		{148 / 255, 203 / 255, 247 / 255}, -- frost
 		{173 / 255, 235 / 255, 66 / 255}, -- unholy
 	},
-	class = {},
-	debuff = {},
-	reaction = {},
-	power = {},
 	selection = {
 		[ 0] = {255 / 255, 0 / 255, 0 / 255}, -- HOSTILE
 		[ 1] = {255 / 255, 129 / 255, 0 / 255}, -- UNFRIENDLY
@@ -38,6 +34,10 @@ local colors = {
 		-- [12] = {255 / 255, 255 / 255, 139 / 255}, -- SELF, buggy
 		[13] = {0 / 255, 153 / 255, 0 / 255}, -- BATTLEGROUND_FRIENDLY_PVP
 	},
+	class = {},
+	debuff = {},
+	reaction = {},
+	power = {},
 }
 
 -- We do this because people edit the vars directly, and changing the default

--- a/colors.lua
+++ b/colors.lua
@@ -31,7 +31,7 @@ local colors = {
 		[ 9] = {128 / 255, 128 / 255, 128 / 255}, -- DEAD
 		-- [10] = {}, -- COMMENTATOR_TEAM_1, unavailable to players
 		-- [11] = {}, -- COMMENTATOR_TEAM_2, unavailable to players
-		-- [12] = {255 / 255, 255 / 255, 139 / 255}, -- SELF, buggy
+		[12] = {255 / 255, 255 / 255, 139 / 255}, -- SELF, buggy
 		[13] = {0 / 255, 153 / 255, 0 / 255}, -- BATTLEGROUND_FRIENDLY_PVP
 	},
 	class = {},

--- a/colors.lua
+++ b/colors.lua
@@ -2,6 +2,8 @@ local parent, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
+local print = Private.print
+
 local frame_metatable = Private.frame_metatable
 
 local colors = {
@@ -122,6 +124,10 @@ function oUF:UnitSelectionColor(unit)
 	elseif r == 0 and g == 255 and b == 0 then
 		return self.colors.reaction[5][1], self.colors.reaction[5][2], self.colors.reaction[5][3]
 	elseif r == 0 and g == 0 and b == 255 then
+		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+	else
+		-- turns out there's still some unknown colours, default to blue for the time being
+		-- print("|cffffd200Unknown colour:|r", r, g, b)
 		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
 	end
 end

--- a/colors.lua
+++ b/colors.lua
@@ -35,7 +35,7 @@ local colors = {
 		[ 9] = {128 / 255, 128 / 255, 128 / 255}, -- DEAD
 		-- [10] = {}, -- COMMENTATOR_TEAM_1, unavailable to players
 		-- [11] = {}, -- COMMENTATOR_TEAM_2, unavailable to players
-		[12] = {255 / 255, 255 / 255, 139 / 255}, -- SELF
+		-- [12] = {255 / 255, 255 / 255, 139 / 255}, -- SELF, buggy
 		[13] = {0 / 255, 153 / 255, 0 / 255}, -- BATTLEGROUND_FRIENDLY_PVP
 	},
 }

--- a/colors.lua
+++ b/colors.lua
@@ -44,6 +44,14 @@ local colors = {
 	},
 }
 
+colors.selection[255 * 65536 + 255 * 256 + 139] = colors.selection[1]
+colors.selection[255 * 65536 + 255 * 256 +   0] = colors.selection[2]
+colors.selection[255 * 65536 + 129 * 256 +   0] = colors.selection[3]
+colors.selection[255 * 65536 +   0 * 256 +   0] = colors.selection[4]
+colors.selection[128 * 65536 + 128 * 256 + 128] = colors.selection[5]
+colors.selection[  0 * 65536 + 255 * 256 +   0] = colors.selection[6]
+colors.selection[  0 * 65536 +   0 * 256 + 255] = colors.selection[7]
+
 -- We do this because people edit the vars directly, and changing the default
 -- globals makes SPICE FLOW!
 local function customClassColors()
@@ -120,34 +128,16 @@ colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
 
-local function round(v)
-	return math.floor(v + 0.5)
-end
-
 --[[ Colors: oUF:UnitSelectionColor(unit) or frame:UnitSelectionColor(unit)
 
 --]]
 function oUF:UnitSelectionColor(unit)
 	local r, g, b = UnitSelectionColor(unit)
-	r, g, b = round(r * 255), round(g * 255), round(b * 255)
+	r = math.ceil(r * 255) * 65536 + math.ceil(g * 255) * 256 + math.ceil(b * 255)
 
-	local color
-	if(r == 255 and g == 255 and b == 139) then
-		color = self.colors.selection[1]
-	elseif(r == 255 and g == 255 and b == 0) then
-		color = self.colors.selection[2]
-	elseif(r == 255 and g == 129 and b == 0) then
-		color = self.colors.selection[3]
-	elseif(r == 255 and g == 0 and b == 0) then
-		color = self.colors.selection[4]
-	elseif(r == 128 and g == 128 and b == 128) then
-		color = self.colors.selection[5]
-	elseif(r == 0 and g == 255 and b == 0) then
-		color = self.colors.selection[6]
-	elseif(r == 0 and g == 0 and b == 255) then
-		color = self.colors.selection[7]
-	else
-		-- print("|cffffd200Unknown colour:|r", r, g, b)
+	local color = self.colors.selection[r]
+	if(not color) then
+		-- print("|cffffd200Unknown colour:|r", UnitSelectionColor(unit))
 		color = self.colors.selection[7]
 	end
 

--- a/colors.lua
+++ b/colors.lua
@@ -30,7 +30,7 @@ local colors = {
 		{255 / 255, 255 / 255, 139 / 255},
 		-- yellow, used for neutral units
 		{255 / 255, 255 / 255, 0 / 255},
-		-- orange, used for non-interactive unfriendly units
+		-- orange, used for unfriendly units
 		{255 / 255, 129 / 255, 0 / 255},
 		-- red, used for hostile units
 		{255 / 255, 0 / 255, 0 /255},
@@ -38,8 +38,7 @@ local colors = {
 		{128 / 255, 128 / 255, 128 / 255},
 		-- green, used for friendly units
 		{0 / 255, 255 / 255, 0 / 255},
-		-- blue, the default colour, also used for friendly player names in dungeons, unattackable
-		-- players in sanctuaries, etc.
+		-- blue, the default colour, mainly used for players in dungeons, raids, and sanctuaries
 		{0 / 255, 0 / 255, 255 / 255},
 	},
 }
@@ -134,6 +133,12 @@ colors.power[18] = colors.power.PAIN
 function oUF:UnitSelectionColor(unit)
 	local r, g, b = UnitSelectionColor(unit)
 	r = math.ceil(r * 255) * 65536 + math.ceil(g * 255) * 256 + math.ceil(b * 255)
+
+	-- BUG: When targeting yourself while in combat, UnitSelectionColor for "player" or any other unit that's actually
+	-- player returns either green or blue instead of intended light yellow
+	if(UnitIsUnit(unit, 'player') and UnitAffectingCombat('player')) then
+		r = 16777099 -- 255 * 65536 + 255 * 256 + 139
+	end
 
 	local color = self.colors.selection[r]
 	if(not color) then

--- a/colors.lua
+++ b/colors.lua
@@ -22,10 +22,26 @@ local colors = {
 	},
 	class = {},
 	debuff = {},
-	reaction = {
-		[0] = {0, 0, 1},
-	},
+	reaction = {},
 	power = {},
+	selection = {
+		-- these colours are sorted by r, then by g, then by b
+		-- very light yellow, used for player's character while in combat
+		{255 / 255, 255 / 255, 139 / 255},
+		-- yellow, used for neutral units
+		{255 / 255, 255 / 255, 0 / 255},
+		-- orange, used for non-interactive unfriendly units
+		{255 / 255, 129 / 255, 0 / 255},
+		-- red, used for hostile units
+		{255 / 255, 0 / 255, 0 /255},
+		-- grey, used for dead units
+		{128 / 255, 128 / 255, 128 / 255},
+		-- green, used for friendly units
+		{0 / 255, 255 / 255, 0 / 255},
+		-- blue, the default colour, also used for friendly player names in dungeons, unattackable
+		-- players in sanctuaries, etc.
+		{0 / 255, 0 / 255, 255 / 255},
+	},
 }
 
 -- We do this because people edit the vars directly, and changing the default
@@ -115,21 +131,27 @@ function oUF:UnitSelectionColor(unit)
 	local r, g, b = UnitSelectionColor(unit)
 	r, g, b = round(r * 255), round(g * 255), round(b * 255)
 
-	if r == 255 and g == 255 and b == 0 then
-		return self.colors.reaction[4][1], self.colors.reaction[4][2], self.colors.reaction[4][3]
-	elseif r == 255 and g == 129 and b == 0 then
-		return self.colors.reaction[3][1], self.colors.reaction[3][2], self.colors.reaction[3][3]
-	elseif r == 255 and g == 0 and b == 0 then
-		return self.colors.reaction[2][1], self.colors.reaction[2][2], self.colors.reaction[2][3]
-	elseif r == 0 and g == 255 and b == 0 then
-		return self.colors.reaction[5][1], self.colors.reaction[5][2], self.colors.reaction[5][3]
-	elseif r == 0 and g == 0 and b == 255 then
-		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+	local color
+	if(r == 255 and g == 255 and b == 139) then
+		color = self.colors.selection[1]
+	elseif(r == 255 and g == 255 and b == 0) then
+		color = self.colors.selection[2]
+	elseif(r == 255 and g == 129 and b == 0) then
+		color = self.colors.selection[3]
+	elseif(r == 255 and g == 0 and b == 0) then
+		color = self.colors.selection[4]
+	elseif(r == 128 and g == 128 and b == 128) then
+		color = self.colors.selection[5]
+	elseif(r == 0 and g == 255 and b == 0) then
+		color = self.colors.selection[6]
+	elseif(r == 0 and g == 0 and b == 255) then
+		color = self.colors.selection[7]
 	else
-		-- turns out there's still some unknown colours, default to blue for the time being
 		-- print("|cffffd200Unknown colour:|r", r, g, b)
-		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+		color = self.colors.selection[7]
 	end
+
+	return color[1], color[2], color[3]
 end
 
 local function colorsAndPercent(a, b, ...)

--- a/colors.lua
+++ b/colors.lua
@@ -25,31 +25,22 @@ local colors = {
 	reaction = {},
 	power = {},
 	selection = {
-		-- these colours are sorted by r, then by g, then by b
-		-- very light yellow, used for player's character while in combat
-		{255 / 255, 255 / 255, 139 / 255},
-		-- yellow, used for neutral units
-		{255 / 255, 255 / 255, 0 / 255},
-		-- orange, used for unfriendly units
-		{255 / 255, 129 / 255, 0 / 255},
-		-- red, used for hostile units
-		{255 / 255, 0 / 255, 0 /255},
-		-- grey, used for dead units
-		{128 / 255, 128 / 255, 128 / 255},
-		-- green, used for friendly units
-		{0 / 255, 255 / 255, 0 / 255},
-		-- blue, the default colour, mainly used for players in dungeons, raids, and sanctuaries
-		{0 / 255, 0 / 255, 255 / 255},
+		[ 0] = {255 / 255, 0 / 255, 0 / 255}, -- HOSTILE
+		[ 1] = {255 / 255, 129 / 255, 0 / 255}, -- UNFRIENDLY
+		[ 2] = {255 / 255, 255 / 255, 0 / 255}, -- NEUTRAL
+		[ 3] = {0 / 255, 255 / 255, 0 / 255}, -- FRIENDLY
+		[ 4] = {0 / 255, 0 / 255, 255 / 255}, -- PLAYER_SIMPLE
+		[ 5] = {96 / 255, 96 / 255, 255 / 255}, -- PLAYER_EXTENDED
+		[ 6] = {170 / 255, 170 / 255, 255 / 255}, -- PARTY
+		[ 7] = {170 / 255, 255 / 255, 170 / 255}, -- PARTY_PVP
+		[ 8] = {83 / 255, 201 / 255, 255 / 255}, -- FRIEND
+		[ 9] = {128 / 255, 128 / 255, 128 / 255}, -- DEAD
+		-- [10] = {}, -- COMMENTATOR_TEAM_1, unavailable to players
+		-- [11] = {}, -- COMMENTATOR_TEAM_2, unavailable to players
+		[12] = {255 / 255, 255 / 255, 139 / 255}, -- SELF
+		[13] = {0 / 255, 153 / 255, 0 / 255}, -- BATTLEGROUND_FRIENDLY_PVP
 	},
 }
-
-colors.selection[255 * 65536 + 255 * 256 + 139] = colors.selection[1]
-colors.selection[255 * 65536 + 255 * 256 +   0] = colors.selection[2]
-colors.selection[255 * 65536 + 129 * 256 +   0] = colors.selection[3]
-colors.selection[255 * 65536 +   0 * 256 +   0] = colors.selection[4]
-colors.selection[128 * 65536 + 128 * 256 + 128] = colors.selection[5]
-colors.selection[  0 * 65536 + 255 * 256 +   0] = colors.selection[6]
-colors.selection[  0 * 65536 +   0 * 256 + 255] = colors.selection[7]
 
 -- We do this because people edit the vars directly, and changing the default
 -- globals makes SPICE FLOW!
@@ -126,28 +117,6 @@ colors.power[13] = colors.power.INSANITY
 colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
-
---[[ Colors: oUF:UnitSelectionColor(unit) or frame:UnitSelectionColor(unit)
-
---]]
-function oUF:UnitSelectionColor(unit)
-	local r, g, b = UnitSelectionColor(unit)
-	r = math.ceil(r * 255) * 65536 + math.ceil(g * 255) * 256 + math.ceil(b * 255)
-
-	-- BUG: When targeting yourself while in combat, UnitSelectionColor for "player" or any other unit that's actually
-	-- player returns either green or blue instead of intended light yellow
-	if(UnitIsUnit(unit, 'player') and UnitAffectingCombat('player')) then
-		r = 16777099 -- 255 * 65536 + 255 * 256 + 139
-	end
-
-	local color = self.colors.selection[r]
-	if(not color) then
-		-- print("|cffffd200Unknown colour:|r", UnitSelectionColor(unit))
-		color = self.colors.selection[7]
-	end
-
-	return color[1], color[2], color[3]
-end
 
 local function colorsAndPercent(a, b, ...)
 	if(a <= 0 or b == 0) then

--- a/colors.lua
+++ b/colors.lua
@@ -153,7 +153,7 @@ local function colorsAndPercent(a, b, ...)
 	if(a <= 0 or b == 0) then
 		return nil, ...
 	elseif(a >= b) then
-		return nil, select(select('#', ...) - 2, ...)
+		return nil, select(-3, ...)
 	end
 
 	local num = select('#', ...) / 3

--- a/colors.lua
+++ b/colors.lua
@@ -20,7 +20,9 @@ local colors = {
 	},
 	class = {},
 	debuff = {},
-	reaction = {},
+	reaction = {
+		[0] = {0, 0, 1},
+	},
 	power = {},
 }
 
@@ -99,6 +101,30 @@ colors.power[13] = colors.power.INSANITY
 colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
+
+local function round(v)
+	return math.floor(v + 0.5)
+end
+
+--[[ Colors: oUF:UnitSelectionColor(unit) or frame:UnitSelectionColor(unit)
+
+--]]
+function oUF:UnitSelectionColor(unit)
+	local r, g, b = UnitSelectionColor(unit)
+	r, g, b = round(r * 255), round(g * 255), round(b * 255)
+
+	if r == 255 and g == 255 and b == 0 then
+		return self.colors.reaction[4][1], self.colors.reaction[4][2], self.colors.reaction[4][3]
+	elseif r == 255 and g == 129 and b == 0 then
+		return self.colors.reaction[3][1], self.colors.reaction[3][2], self.colors.reaction[3][3]
+	elseif r == 255 and g == 0 and b == 0 then
+		return self.colors.reaction[2][1], self.colors.reaction[2][2], self.colors.reaction[2][3]
+	elseif r == 0 and g == 255 and b == 0 then
+		return self.colors.reaction[5][1], self.colors.reaction[5][2], self.colors.reaction[5][3]
+	elseif r == 0 and g == 0 and b == 255 then
+		return self.colors.reaction[0][1], self.colors.reaction[0][2], self.colors.reaction[0][3]
+	end
+end
 
 local function colorsAndPercent(a, b, ...)
 	if(a <= 0 or b == 0) then
@@ -245,3 +271,4 @@ oUF.useHCYColorGradient = false
 
 frame_metatable.__index.colors = colors
 frame_metatable.__index.ColorGradient = oUF.ColorGradient
+frame_metatable.__index.UnitSelectionColor = oUF.UnitSelectionColor

--- a/colors.lua
+++ b/colors.lua
@@ -2,8 +2,6 @@ local parent, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local print = Private.print
-
 local frame_metatable = Private.frame_metatable
 
 local colors = {
@@ -263,4 +261,3 @@ oUF.useHCYColorGradient = false
 
 frame_metatable.__index.colors = colors
 frame_metatable.__index.ColorGradient = oUF.ColorGradient
-frame_metatable.__index.UnitSelectionColor = oUF.UnitSelectionColor

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -216,6 +216,7 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_MAXHEALTH', Path)
 		self:RegisterEvent('UNIT_CONNECTION', Path)
 		self:RegisterEvent('UNIT_FACTION', Path) -- For tapping
+		self:RegisterEvent('UNIT_FLAGS', Path) -- For selection
 
 		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
@@ -241,6 +242,7 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_MAXHEALTH', Path)
 		self:UnregisterEvent('UNIT_CONNECTION', Path)
 		self:UnregisterEvent('UNIT_FACTION', Path)
+		self:UnregisterEvent('UNIT_FLAGS', Path)
 	end
 end
 

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -93,7 +93,7 @@ local function UpdateColor(element, unit, cur, max)
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
 	elseif(element.colorSelection) then
-		r, g, b = parent:UnitSelectionColor(unit)
+		t = parent.colors.selection[UnitSelectionType(unit, true)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -29,7 +29,8 @@ The following options are listed by priority. The first check that returns true 
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
-.colorSelection    - ??? (boolean)
+.colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
+                     `selection` is defined by the return value of [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -33,7 +33,8 @@ The following options are listed by priority. The first check that returns true 
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
 .colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
-                     `selection` is defined by the return value of [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
+                     `selection` is defined by the return value of Private.UnitSelectionType, a wrapper function
+                     for [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -20,7 +20,7 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 .frequentUpdates                  - Indicates whether to use UNIT_HEALTH_FREQUENT instead of UNIT_HEALTH to update the
                                     bar (boolean)
 .smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
-.considerSelectionInCombatHostile - Indicates whether selection should be considered as hostile while the unit is in
+.considerSelectionInCombatHostile - Indicates whether selection should be considered hostile while the unit is in
                                     combat with the player (boolean)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -78,6 +78,9 @@ The following options are listed by priority. The first check that returns true 
 
 local _, ns = ...
 local oUF = ns.oUF
+local Private = oUF.Private
+
+local UnitSelectionType = Private.UnitSelectionType
 
 local function UpdateColor(element, unit, cur, max)
 	local parent = element.__owner
@@ -92,8 +95,8 @@ local function UpdateColor(element, unit, cur, max)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
-	elseif(element.colorSelection) then
-		t = parent.colors.selection[UnitSelectionType(unit, true)]
+	elseif(element.colorSelection and UnitSelectionType(unit)) then
+		t = parent.colors.selection[UnitSelectionType(unit)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -29,6 +29,7 @@ The following options are listed by priority. The first check that returns true 
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
+.colorSelection    - ??? (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)
@@ -91,6 +92,8 @@ local function UpdateColor(element, unit, cur, max)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
+	elseif(element.colorSelection) then
+		r, g, b = parent:UnitSelectionColor(unit)
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -17,8 +17,11 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 
 ## Options
 
-.frequentUpdates   - Indicates whether to use UNIT_HEALTH_FREQUENT instead of UNIT_HEALTH to update the bar (boolean)
-.smoothGradient    - 9 color values to be used with the .colorSmooth option (table)
+.frequentUpdates                  - Indicates whether to use UNIT_HEALTH_FREQUENT instead of UNIT_HEALTH to update the
+                                    bar (boolean)
+.smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
+.considerSelectionInCombatHostile - Indicates whether selection should be considered as hostile while the unit is in
+                                    combat with the player (boolean)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.
 
@@ -96,8 +99,8 @@ local function UpdateColor(element, unit, cur, max)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
-	elseif(element.colorSelection and UnitSelectionType(unit)) then
-		t = parent.colors.selection[UnitSelectionType(unit)]
+	elseif(element.colorSelection and UnitSelectionType(unit, element.considerSelectionInCombatHostile)) then
+		t = parent.colors.selection[UnitSelectionType(unit, element.considerSelectionInCombatHostile)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -91,6 +91,9 @@ The following options are listed by priority. The first check that returns true 
 
 local _, ns = ...
 local oUF = ns.oUF
+local Private = oUF.Private
+
+local UnitSelectionType = Private.UnitSelectionType
 
 -- sourced from FrameXML/UnitPowerBarAlt.lua
 local ALTERNATE_POWER_INDEX = Enum.PowerType.Alternate or 10
@@ -134,8 +137,8 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
-	elseif(element.colorSelection) then
-		t = parent.colors.selection[UnitSelectionType(unit, true)]
+	elseif(element.colorSelection and UnitSelectionType(unit)) then
+		t = parent.colors.selection[UnitSelectionType(unit)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -26,7 +26,7 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
                                     type (boolean)
 .atlas                            - A custom atlas (string)
 .smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
-.considerSelectionInCombatHostile - Indicates whether selection should be considered as hostile while the unit is in
+.considerSelectionInCombatHostile - Indicates whether selection should be considered hostile while the unit is in
                                     combat with the player (boolean)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -290,6 +290,7 @@ local function Enable(self)
 		self:RegisterEvent('UNIT_CONNECTION', Path)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)
 		self:RegisterEvent('UNIT_FACTION', Path) -- For tapping
+		self:RegisterEvent('UNIT_FLAGS', Path) -- For selection
 
 		if(element:IsObjectType('StatusBar')) then
 			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
@@ -319,6 +320,7 @@ local function Disable(self)
 		self:UnregisterEvent('UNIT_CONNECTION', Path)
 		self:UnregisterEvent('UNIT_MAXPOWER', Path)
 		self:UnregisterEvent('UNIT_FACTION', Path)
+		self:UnregisterEvent('UNIT_FLAGS', Path)
 	end
 end
 

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -42,7 +42,8 @@ The following options are listed by priority. The first check that returns true 
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
-.colorSelection    - ??? (boolean)
+.colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
+                     `selection` is defined by the return value of [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -135,7 +135,7 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
 	elseif(element.colorSelection) then
-		r, g, b = parent:UnitSelectionColor(unit)
+		t = parent.colors.selection[UnitSelectionType(unit, true)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -17,14 +17,17 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 
 ## Options
 
-.frequentUpdates - Indicates whether to use UNIT_POWER_FREQUENT instead UNIT_POWER_UPDATE to update the bar. Only valid
-                   for the player and pet units (boolean)
-.displayAltPower - Use this to let the widget display alternate power if the unit has one. If no alternate power the
-                   display will fall back to primary power (boolean)
-.useAtlas        - Use this to let the widget use an atlas for its texture if `.atlas` is defined on the widget or an
-                   atlas is present in `self.colors.power` for the appropriate power type (boolean)
-.atlas           - A custom atlas (string)
-.smoothGradient  - 9 color values to be used with the .colorSmooth option (table)
+.frequentUpdates                  - Indicates whether to use UNIT_POWER_FREQUENT instead UNIT_POWER_UPDATE to update the
+                                    bar. Only valid for the player and pet units (boolean)
+.displayAltPower                  - Use this to let the widget display alternate power if the unit has one. If no
+                                    alternate power the display will fall back to primary power (boolean)
+.useAtlas                         - Use this to let the widget use an atlas for its texture if `.atlas` is defined on
+                                    the widget or an atlas is present in `self.colors.power` for the appropriate power
+                                    type (boolean)
+.atlas                            - A custom atlas (string)
+.smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
+.considerSelectionInCombatHostile - Indicates whether selection should be considered as hostile while the unit is in
+                                    combat with the player (boolean)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.
 
@@ -138,8 +141,8 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
-	elseif(element.colorSelection and UnitSelectionType(unit)) then
-		t = parent.colors.selection[UnitSelectionType(unit)]
+	elseif(element.colorSelection and UnitSelectionType(unit, element.considerSelectionInCombatHostile)) then
+		t = parent.colors.selection[UnitSelectionType(unit, element.considerSelectionInCombatHostile)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -42,6 +42,7 @@ The following options are listed by priority. The first check that returns true 
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
+.colorSelection    - ??? (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)
@@ -133,6 +134,8 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
+	elseif(element.colorSelection) then
+		r, g, b = parent:UnitSelectionColor(unit)
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -46,7 +46,8 @@ The following options are listed by priority. The first check that returns true 
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
 .colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
-                     `selection` is defined by the return value of [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
+                     `selection` is defined by the return value of Private.UnitSelectionType, a wrapper function
+                     for [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
                      [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)

--- a/private.lua
+++ b/private.lua
@@ -36,3 +36,24 @@ function Private.validateUnit(unit)
 		return not not unit
 	end
 end
+
+local selectionTypes = {
+	[ 0] = 0,
+	[ 1] = 1,
+	[ 2] = 2,
+	[ 3] = 3,
+	[ 4] = 4,
+	[ 5] = 5,
+	[ 6] = 6,
+	[ 7] = 7,
+	[ 8] = 8,
+	[ 9] = 9,
+	-- [10] = 10, -- unavailable to players
+	-- [11] = 11, -- unavailable to players
+	-- [12] = 12, -- buggy
+	[13] = 13,
+}
+
+function Private.UnitSelectionType(unit)
+	return selectionTypes[UnitSelectionType(unit, true)]
+end

--- a/private.lua
+++ b/private.lua
@@ -54,6 +54,10 @@ local selectionTypes = {
 	[13] = 13,
 }
 
-function Private.UnitSelectionType(unit)
-	return selectionTypes[UnitSelectionType(unit, true)]
+function Private.UnitSelectionType(unit, considerHostile)
+	if(considerHostile and UnitThreatSituation("player", unit)) then
+		return 0
+	else
+		return selectionTypes[UnitSelectionType(unit, true)]
+	end
 end

--- a/private.lua
+++ b/private.lua
@@ -50,7 +50,7 @@ local selectionTypes = {
 	[ 9] = 9,
 	-- [10] = 10, -- unavailable to players
 	-- [11] = 11, -- unavailable to players
-	-- [12] = 12, -- buggy
+	-- [12] = 12, -- inconsistent due to bugs and its reliance on cvars
 	[13] = 13,
 }
 

--- a/private.lua
+++ b/private.lua
@@ -55,7 +55,7 @@ local selectionTypes = {
 }
 
 function Private.UnitSelectionType(unit, considerHostile)
-	if(considerHostile and UnitThreatSituation("player", unit)) then
+	if(considerHostile and UnitThreatSituation('player', unit)) then
 		return 0
 	else
 		return selectionTypes[UnitSelectionType(unit, true)]


### PR DESCRIPTION
This PR is the continuation of #467.

In stead of using `UnitSelectionColor` and guessing what's what, this iteration utilises a slightly modified version `UnitSelectionType` that's added in 8.1.5,

`.colorSelection` is pretty much a smarter version of `.colorReaction`.