### PR TITLE
threatindicator: Use a better default texture

### DIFF
--- a/elements/threatindicator.lua
+++ b/elements/threatindicator.lua
@@ -112,8 +112,7 @@ local function Enable(self)
 		self:RegisterEvent('UNIT_THREAT_LIST_UPDATE', Path)
 
 		if(element:IsObjectType('Texture') and not element:GetTexture()) then
-			element:SetTexture([[Interface\Minimap\ObjectIcons]])
-			element:SetTexCoord(6/8, 7/8, 1/8, 2/8)
+			element:SetTexture([[Interface\RAIDFRAME\UI-RaidFrame-Threat]])
 		end
 
 		return true


### PR DESCRIPTION
Blizz updated the texture map we're using for the default texture, so it's a good opportunity to start using proper dedicated textures.

New:
![](https://github.com/Gethe/wow-ui-textures/blob/0f5194985cd3da80b60eb45557925f294b40ddec/RAIDFRAME/UI-RaidFrame-Threat.PNG?raw=true)

Old (Current):
![](https://github.com/Gethe/wow-ui-textures/blob/0f5194985cd3da80b60eb45557925f294b40ddec/MINIMAP/ObjectIcons.PNG?raw=true)