### PR TITLE
elements: do not toggle visibility on enable where it is part of the update process

### DIFF
--- a/elements/alternativepower.lua
+++ b/elements/alternativepower.lua
@@ -175,8 +175,6 @@ local function Enable(self, unit)
 			PlayerPowerBarAlt:UnregisterEvent('PLAYER_ENTERING_WORLD')
 		end
 
-		element:Hide()
-
 		return true
 	end
 end

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -578,8 +578,6 @@ local function Enable(self, unit)
 			safeZone:SetColorTexture(1, 0, 0)
 		end
 
-		element:Hide()
-
 		return true
 	end
 end

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -184,8 +184,6 @@ local function Enable(self)
 		MonkStaggerBar:UnregisterEvent('UNIT_EXITED_VEHICLE')
 		MonkStaggerBar:UnregisterEvent('UPDATE_VEHICLE_ACTIONBAR')
 
-		element:Hide()
-
 		return true
 	end
 end


### PR DESCRIPTION
Toggling visibility on enable may break layouts which have elements depending on the visibility of other elements.

```lua
local function OnHide(altpower)
	local experience = altpower.__owner.Experience
	if (experience) then
		experience.Show = nil
		experience:ForceUpdate()
	end
end
```

`element:Hide()` in `elements/alternativepower.lua` would break the above if oUF_Experience has not yet been enabled (ForceUpdate is not avail). Waiting for PEW/ForceUpdate to toggle visibility is better, because relevant elements should have loaded until then.

This only presented itself with patch 8.1.5, maybe because of graphic changes made behind scenes.

A more resilient approach for the layout would be to check for the presence of ForceUpdate and not as above, so in this case it might be argued upon where the fix should be applied.