### PR TITLE
Update the colouring of elements

### DIFF
--- a/colors.lua
+++ b/colors.lua
@@ -38,6 +38,7 @@ local colors = {
 	debuff = {},
 	reaction = {},
 	power = {},
+	threat = {},
 }
 
 -- We do this because people edit the vars directly, and changing the default
@@ -115,6 +116,10 @@ colors.power[13] = colors.power.INSANITY
 colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
+
+for i = 0, 3 do
+	colors.threat[i] = {GetThreatStatusColor(i)}
+end
 
 local function colorsAndPercent(a, b, ...)
 	if(a <= 0 or b == 0) then

--- a/colors.lua
+++ b/colors.lua
@@ -117,6 +117,10 @@ colors.power[16] = colors.power.ARCANE_CHARGES
 colors.power[17] = colors.power.FURY
 colors.power[18] = colors.power.PAIN
 
+-- alternate power, sourced from FrameXML/CompactUnitFrame.lua
+colors.power.ALTERNATE = {0.7, 0.7, 0.6}
+colors.power[10] = colors.power.ALTERNATE
+
 for i = 0, 3 do
 	colors.threat[i] = {GetThreatStatusColor(i)}
 end

--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -91,6 +91,15 @@ local function UpdateColor(self, event, unit, powerType)
 		end
 	end
 
+	--[[ Callback: AdditionalPower:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
+
+	* self - the AdditionalPower element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(r, g, b)
 	end

--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -91,11 +91,10 @@ local function UpdateColor(self, event, unit, powerType)
 		end
 	end
 
-	--[[ Callback: AdditionalPower:PostUpdateColor(unit, r, g, b)
+	--[[ Callback: AdditionalPower:PostUpdateColor(r, g, b)
 	Called after the element color has been updated.
 
 	* self - the AdditionalPower element
-	* unit - the unit for which the update has been triggered (string)
 	* r    - the red component of the used color (number)[0-1]
 	* g    - the green component of the used color (number)[0-1]
 	* b    - the blue component of the used color (number)[0-1]

--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -178,16 +178,20 @@ local function ElementEnable(self)
 
 	element:Show()
 
+	element.__isEnabled = true
 	Path(self, 'ElementEnable', 'player', ADDITIONAL_POWER_BAR_NAME)
 end
 
 local function ElementDisable(self)
+	local element = self.AdditionalPower
+
 	self:UnregisterEvent('UNIT_MAXPOWER', Path)
 	self:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
 	self:UnregisterEvent('UNIT_POWER_UPDATE', Path)
 
-	self.AdditionalPower:Hide()
+	element:Hide()
 
+	element.__isEnabled = false
 	Path(self, 'ElementDisable', 'player', ADDITIONAL_POWER_BAR_NAME)
 end
 
@@ -204,10 +208,28 @@ local function Visibility(self, event, unit)
 		end
 	end
 
-	if(shouldEnable) then
+	local isEnabled = element.__isEnabled
+
+	if(shouldEnable and not isEnabled) then
 		ElementEnable(self)
-	else
+
+		--[[ Callback: AdditionalPower:PostVisibility(isVisible)
+		Called after the element's visibility has been changed.
+
+		* self      - the AdditionalPower element
+		* isVisible - the current visibility state of the element (boolean)
+		--]]
+		if(element.PostVisibility) then
+			element:PostVisibility(true)
+		end
+	elseif(not shouldEnable and (isEnabled or isEnabled == nil)) then
 		ElementDisable(self)
+
+		if(element.PostVisibility) then
+			element:PostVisibility(false)
+		end
+	elseif(shouldEnable and isEnabled) then
+		Path(self, event, unit, ADDITIONAL_POWER_BAR_NAME)
 	end
 end
 

--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -20,8 +20,6 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 
 .frequentUpdates - Indicates whether to use UNIT_POWER_FREQUENT instead UNIT_POWER_UPDATE to update the bar (boolean)
 .displayPairs    - Use to override display pairs. (table)
-.useAtlas        - Use this to let the widget use an atlas for its texture if an atlas is present in `self.colors.power`
-                   for the additional power type (boolean)
 .smoothGradient  - 9 color values to be used with the .colorSmooth option (table)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.
@@ -70,13 +68,9 @@ local function UpdateColor(self, event, unit, powerType)
 	if(not (unit and UnitIsUnit(unit, 'player') and powerType == ADDITIONAL_POWER_BAR_NAME)) then return end
 	local element = self.AdditionalPower
 
-	local r, g, b, t, atlas
+	local r, g, b, t
 	if(element.colorPower) then
 		t = self.colors.power[ADDITIONAL_POWER_BAR_INDEX]
-
-		if(element.useAtlas and t and t.atlas) then
-			atlas = t.atlas
-		end
 	elseif(element.colorClass) then
 		t = self.colors.class[playerClass]
 	elseif(element.colorSmooth) then
@@ -87,21 +81,14 @@ local function UpdateColor(self, event, unit, powerType)
 		r, g, b = t[1], t[2], t[3]
 	end
 
-	if(atlas) then
-		element:SetStatusBarAtlas(atlas)
-		element:SetStatusBarColor(1, 1, 1)
-	else
-		element:SetStatusBarTexture(element.texture)
+	if(b) then
+		element:SetStatusBarColor(r, g, b)
 
-		if(b) then
-			element:SetStatusBarColor(r, g, b)
+		local bg = element.bg
+		if(bg) then
+			local mu = bg.multiplier or 1
+			bg:SetVertexColor(r * mu, g * mu, b * mu)
 		end
-	end
-
-	local bg = element.bg
-	if(bg and b) then
-		local mu = bg.multiplier or 1
-		bg:SetVertexColor(r * mu, g * mu, b * mu)
 	end
 
 	if(element.PostUpdateColor) then
@@ -280,9 +267,8 @@ local function Enable(self, unit)
 			element.displayPairs = CopyTable(ALT_MANA_BAR_PAIR_DISPLAY_INFO)
 		end
 
-		if(element:IsObjectType('StatusBar')) then
-			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
-			element:SetStatusBarTexture(element.texture)
+		if(element:IsObjectType('StatusBar') and not (element:GetStatusBarTexture() or element:GetStatusBarAtlas())) then
+			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 		end
 
 		return true

--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -105,7 +105,7 @@ local function UpdateColor(self, event, unit, powerType)
 	end
 
 	if(element.PostUpdateColor) then
-		element:PostUpdateColor(unit, r, g, b)
+		element:PostUpdateColor(r, g, b)
 	end
 end
 
@@ -134,12 +134,11 @@ local function Update(self, event, unit, powerType)
 	Called after the element has been updated.
 
 	* self - the AdditionalPower element
-	* unit - the unit for which the update has been triggered (string)
 	* cur  - the current value of the player's additional power (number)
 	* max  - the maximum value of the player's additional power (number)
 	--]]
 	if(element.PostUpdate) then
-		return element:PostUpdate(unit, cur, max)
+		return element:PostUpdate(cur, max)
 	end
 end
 

--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -18,15 +18,20 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 
 ## Options
 
-.smoothGradient - 9 color values to be used with the .colorSmooth option (table)
+.frequentUpdates - Indicates whether to use UNIT_POWER_FREQUENT instead UNIT_POWER_UPDATE to update the bar (boolean)
+.displayPairs    - Use to override display pairs. (table)
+.useAtlas        - Use this to let the widget use an atlas for its texture if an atlas is present in `self.colors.power`
+                   for the additional power type (boolean)
+.smoothGradient  - 9 color values to be used with the .colorSmooth option (table)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.
 
-.colorClass   - Use `self.colors.class[class]` to color the bar based on the player's class. (boolean)
-.colorSmooth  - Use `self.colors.smooth` to color the bar with a smooth gradient based on the player's current additional
-               power percentage (boolean)
-.colorPower   - Use `self.colors.power[token]` to color the bar based on the player's additional power type. (boolean)
-.displayPairs - Use to override display pairs. (table)
+.colorPower  - Use `self.colors.power[token]` to color the bar based on the player's additional power type
+               (boolean)
+.colorClass  - Use `self.colors.class[class]` to color the bar based on unit class. `class` is defined by the
+               second return of [UnitClass](http://wowprogramming.com/docs/api/UnitClass.html) (boolean)
+.colorSmooth - Use `self.colors.smooth` to color the bar with a smooth gradient based on the player's current
+               additional power percentage (boolean)
 
 ## Sub-Widget Options
 
@@ -61,58 +66,69 @@ local ADDITIONAL_POWER_BAR_NAME = ADDITIONAL_POWER_BAR_NAME or 'MANA'
 local ADDITIONAL_POWER_BAR_INDEX = ADDITIONAL_POWER_BAR_INDEX or 0
 local ALT_MANA_BAR_PAIR_DISPLAY_INFO = ALT_MANA_BAR_PAIR_DISPLAY_INFO
 
-local function UpdateColor(element, cur, max)
-	local parent = element.__owner
+local function UpdateColor(self, event, unit, powerType)
+	if(not (unit and UnitIsUnit(unit, 'player') and powerType == ADDITIONAL_POWER_BAR_NAME)) then return end
+	local element = self.AdditionalPower
 
-	local r, g, b, t
-	if(element.colorClass) then
-		t = parent.colors.class[playerClass]
+	local r, g, b, t, atlas
+	if(element.colorPower) then
+		t = self.colors.power[ADDITIONAL_POWER_BAR_INDEX]
+
+		if(element.useAtlas and t and t.atlas) then
+			atlas = t.atlas
+		end
+	elseif(element.colorClass) then
+		t = self.colors.class[playerClass]
 	elseif(element.colorSmooth) then
-		r, g, b = parent:ColorGradient(cur, max, unpack(element.smoothGradient or parent.colors.smooth))
-	elseif(element.colorPower) then
-		t = parent.colors.power[ADDITIONAL_POWER_BAR_NAME]
+		r, g, b = self:ColorGradient(element.cur or 1, element.max or 1, unpack(element.smoothGradient or self.colors.smooth))
 	end
 
 	if(t) then
 		r, g, b = t[1], t[2], t[3]
 	end
 
-	if(b) then
-		element:SetStatusBarColor(r, g, b)
+	if(atlas) then
+		element:SetStatusBarAtlas(atlas)
+		element:SetStatusBarColor(1, 1, 1)
+	else
+		element:SetStatusBarTexture(element.texture)
 
-		local bg = element.bg
-		if(bg) then
-			local mu = bg.multiplier or 1
-			bg:SetVertexColor(r * mu, g * mu, b * mu)
+		if(b) then
+			element:SetStatusBarColor(r, g, b)
 		end
+	end
+
+	local bg = element.bg
+	if(bg and b) then
+		local mu = bg.multiplier or 1
+		bg:SetVertexColor(r * mu, g * mu, b * mu)
+	end
+
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(unit, r, g, b)
 	end
 end
 
-local function Update(self, event, unit, powertype)
-	if(not (unit and UnitIsUnit(unit, 'player') and powertype == ADDITIONAL_POWER_BAR_NAME)) then return end
-
+local function Update(self, event, unit, powerType)
+	if(not (unit and UnitIsUnit(unit, 'player') and powerType == ADDITIONAL_POWER_BAR_NAME)) then return end
 	local element = self.AdditionalPower
+
 	--[[ Callback: AdditionalPower:PreUpdate(unit)
 	Called before the element has been updated.
 
 	* self - the AdditionalPower element
 	* unit - the unit for which the update has been triggered (string)
 	--]]
-	if(element.PreUpdate) then element:PreUpdate(unit) end
+	if(element.PreUpdate) then
+		element:PreUpdate(unit)
+	end
 
-	local cur = UnitPower('player', ADDITIONAL_POWER_BAR_INDEX)
-	local max = UnitPowerMax('player', ADDITIONAL_POWER_BAR_INDEX)
+	local cur, max = UnitPower('player', ADDITIONAL_POWER_BAR_INDEX), UnitPowerMax('player', ADDITIONAL_POWER_BAR_INDEX)
 	element:SetMinMaxValues(0, max)
 	element:SetValue(cur)
 
-	--[[ Override: AdditionalPower:UpdateColor(cur, max)
-	Used to completely override the internal function for updating the widget's colors.
-
-	* self - the AdditionalPower element
-	* cur  - the current value of the player's additional power (number)
-	* max  - the maximum value of the player's additional power (number)
-	--]]
-	element:UpdateColor(cur, max)
+	element.cur = cur
+	element.max = max
 
 	--[[ Callback: AdditionalPower:PostUpdate(unit, cur, max)
 	Called after the element has been updated.
@@ -136,21 +152,39 @@ local function Path(self, ...)
 	* unit  - the unit accompanying the event (string)
 	* ...   - the arguments accompanying the event
 	--]]
-	return (self.AdditionalPower.Override or Update) (self, ...)
+	(self.AdditionalPower.Override or Update) (self, ...);
+
+	--[[ Override: AdditionalPower.UpdateColor(self, event, unit, ...)
+	Used to completely override the internal function for updating the widgets' colors.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* unit  - the unit accompanying the event (string)
+	* ...   - the arguments accompanying the event
+	--]]
+	(self.AdditionalPower.UpdateColor or UpdateColor) (self, ...)
 end
 
 local function ElementEnable(self)
-	self:RegisterEvent('UNIT_POWER_FREQUENT', Path)
+	local element = self.AdditionalPower
+
+	if(element.frequentUpdates) then
+		self:RegisterEvent('UNIT_POWER_FREQUENT', Path)
+	else
+		self:RegisterEvent('UNIT_POWER_UPDATE', Path)
+	end
+
 	self:RegisterEvent('UNIT_MAXPOWER', Path)
 
-	self.AdditionalPower:Show()
+	element:Show()
 
 	Path(self, 'ElementEnable', 'player', ADDITIONAL_POWER_BAR_NAME)
 end
 
 local function ElementDisable(self)
-	self:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
 	self:UnregisterEvent('UNIT_MAXPOWER', Path)
+	self:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
+	self:UnregisterEvent('UNIT_POWER_UPDATE', Path)
 
 	self.AdditionalPower:Hide()
 
@@ -185,11 +219,31 @@ local function VisibilityPath(self, ...)
 	* event - the event triggering the update (string)
 	* unit  - the unit accompanying the event (string)
 	--]]
-	return (self.AdditionalPower.OverrideVisibility or Visibility) (self, ...)
+	(self.AdditionalPower.OverrideVisibility or Visibility) (self, ...)
 end
 
 local function ForceUpdate(element)
-	return VisibilityPath(element.__owner, 'ForceUpdate', element.__owner.unit)
+	VisibilityPath(element.__owner, 'ForceUpdate', element.__owner.unit)
+end
+
+--[[ Power:SetFrequentUpdates(state)
+Used to toggle frequent updates.
+
+* self  - the Power element
+* state - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetFrequentUpdates(element, state, isForced)
+	if(element.frequentUpdates ~= state or isForced) then
+		element.frequentUpdates = state
+		if(state) then
+			element.__owner:UnregisterEvent('UNIT_POWER_UPDATE', Path)
+			element.__owner:RegisterEvent('UNIT_POWER_FREQUENT', Path)
+		else
+			element.__owner:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
+			element.__owner:RegisterEvent('UNIT_POWER_UPDATE', Path)
+		end
+	end
 end
 
 local function Enable(self, unit)
@@ -197,6 +251,7 @@ local function Enable(self, unit)
 	if(element and UnitIsUnit(unit, 'player')) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
+		element.SetFrequentUpdates = SetFrequentUpdates
 
 		self:RegisterEvent('UNIT_DISPLAYPOWER', VisibilityPath)
 
@@ -204,12 +259,9 @@ local function Enable(self, unit)
 			element.displayPairs = CopyTable(ALT_MANA_BAR_PAIR_DISPLAY_INFO)
 		end
 
-		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
-			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
-		end
-
-		if(not element.UpdateColor) then
-			element.UpdateColor = UpdateColor
+		if(element:IsObjectType('StatusBar')) then
+			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
+			element:SetStatusBarTexture(element.texture)
 		end
 
 		return true

--- a/elements/alternativepower.lua
+++ b/elements/alternativepower.lua
@@ -13,6 +13,32 @@ AlternativePower - A `StatusBar` used to represent the unit's alternative power.
 If mouse interactivity is enabled for the widget, `OnEnter` and/or `OnLeave` handlers will be set to display a tooltip.
 A default texture will be applied if the widget is a StatusBar and doesn't have a texture set.
 
+## Options
+
+.useAtlas                         - Use this to let the widget use an atlas for its texture if an atlas is present in
+                                    `self.colors.power` for the alternative power type (boolean)
+.smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
+.considerSelectionInCombatHostile - Indicates whether selection should be considered hostile while the unit is in
+                                    combat with the player (boolean)
+
+The following options are listed by priority. The first check that returns true decides the color of the bar.
+
+.colorThreat       - Use `self.colors.threat[threat]` to color the bar based on the unit's threat status. `threat` is
+                     defined by the first return of [UnitThreatSituation](https://wow.gamepedia.com/API_UnitThreatSituation) (boolean)
+.colorPower        - Use `self.colors.power[token]` to color the bar based on the unit's alternative power type
+                     (boolean)
+.colorClass        - Use `self.colors.class[class]` to color the bar based on unit class. `class` is defined by the
+                     second return of [UnitClass](http://wowprogramming.com/docs/api/UnitClass.html) (boolean)
+.colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
+.colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
+                     `selection` is defined by the return value of Private.unitSelectionType, a wrapper function
+                     for [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
+.colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
+                     unit. `reaction` is defined by the return value of
+                     [UnitReaction](http://wowprogramming.com/docs/api/UnitReaction.html) (boolean)
+.colorSmooth       - Use `self.colors.smooth` to color the bar with a smooth gradient based on the unit's current
+                     alternative power percentage (boolean)
+
 ## Examples
 
     -- Position and size
@@ -28,9 +54,13 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 
 local _, ns = ...
 local oUF = ns.oUF
+local Private = oUF.Private
+
+local unitSelectionType = Private.unitSelectionType
 
 -- sourced from FrameXML/UnitPowerBarAlt.lua
 local ALTERNATE_POWER_INDEX = Enum.PowerType.Alternate or 10
+local ALTERNATE_POWER_NAME = 'ALTERNATE'
 
 local function updateTooltip(self)
 	local name, tooltip = GetUnitPowerBarStringsByID(self.__barID)
@@ -50,9 +80,60 @@ local function onLeave()
 	GameTooltip:Hide()
 end
 
-local function Update(self, event, unit, powerType)
-	if(self.unit ~= unit or powerType ~= 'ALTERNATE') then return end
+local function UpdateColor(self, event, unit, powerType)
+	if(self.unit ~= unit or powerType ~= ALTERNATE_POWER_NAME) then return end
+	local element = self.AlternativePower
 
+	local r, g, b, t, atlas
+	if(element.colorThreat and not UnitPlayerControlled(unit) and UnitThreatSituation('player', unit)) then
+		t =  self.colors.threat[UnitThreatSituation('player', unit)]
+	elseif(element.colorPower) then
+		t = self.colors.power[ALTERNATE_POWER_INDEX]
+
+		if(element.useAtlas and t and t.atlas) then
+			atlas = t.atlas
+		end
+	elseif(element.colorClass and UnitIsPlayer(unit)) or
+		(element.colorClassNPC and not UnitIsPlayer(unit)) then
+		local _, class = UnitClass(unit)
+		t = self.colors.class[class]
+	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then
+		t = self.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
+	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
+		t = self.colors.reaction[UnitReaction(unit, 'player')]
+	elseif(element.colorSmooth) then
+		local adjust = 0 - (element.min or 0)
+		r, g, b = self:ColorGradient((element.cur or 1) + adjust, (element.max or 1) + adjust, unpack(element.smoothGradient or self.colors.smooth))
+	end
+
+	if(t) then
+		r, g, b = t[1], t[2], t[3]
+	end
+
+	if(atlas) then
+		element:SetStatusBarAtlas(atlas)
+		element:SetStatusBarColor(1, 1, 1)
+	else
+		element:SetStatusBarTexture(element.texture)
+
+		if(b) then
+			element:SetStatusBarColor(r, g, b)
+		end
+	end
+
+	local bg = element.bg
+	if(bg and b) then
+		local mu = bg.multiplier or 1
+		bg:SetVertexColor(r * mu, g * mu, b * mu)
+	end
+
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(unit, r, g, b)
+	end
+end
+
+local function Update(self, event, unit, powerType)
+	if(self.unit ~= unit or powerType ~= ALTERNATE_POWER_NAME) then return end
 	local element = self.AlternativePower
 
 	--[[ Callback: AlternativePower:PreUpdate()
@@ -66,7 +147,6 @@ local function Update(self, event, unit, powerType)
 
 	local cur, max, min
 	local barInfo = element.__barInfo
-
 	if(barInfo) then
 		cur = UnitPower(unit, ALTERNATE_POWER_INDEX)
 		max = UnitPowerMax(unit, ALTERNATE_POWER_INDEX)
@@ -74,6 +154,10 @@ local function Update(self, event, unit, powerType)
 		element:SetMinMaxValues(min, max)
 		element:SetValue(cur)
 	end
+
+	element.cur = cur
+	element.min = min
+	element.max = max
 
 	--[[ Callback: AlternativePower:PostUpdate(unit, cur, min, max)
 	Called after the element has been updated.
@@ -98,7 +182,17 @@ local function Path(self, ...)
 	* unit  - the unit accompanying the event (string)
 	* ...   - the arguments accompanying the event
 	--]]
-	return (self.AlternativePower.Override or Update)(self, ...)
+	(self.AlternativePower.Override or Update) (self, ...);
+
+	--[[ Override: AlternativePower.UpdateColor(self, event, unit, ...)
+	Used to completely override the internal function for updating the widgets' colors.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* unit  - the unit accompanying the event (string)
+	* ...   - the arguments accompanying the event
+	--]]
+	(self.AlternativePower.UpdateColor or UpdateColor) (self, ...)
 end
 
 local function Visibility(self, event, unit)
@@ -110,20 +204,21 @@ local function Visibility(self, event, unit)
 	element.__barID = barID
 	element.__barInfo = barInfo
 	if(barInfo and (barInfo.showOnRaid and (UnitInParty(unit) or UnitInRaid(unit))
-		or not barInfo.hideFromOthers or UnitIsUnit(unit, 'player')
+		or not barInfo.hideFromOthers
+		or UnitIsUnit(unit, 'player')
 		or UnitIsUnit(self.realUnit, 'player')))
 	then
 		self:RegisterEvent('UNIT_POWER_UPDATE', Path)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)
 
 		element:Show()
-		Path(self, event, unit, 'ALTERNATE')
+		Path(self, event, unit, ALTERNATE_POWER_NAME)
 	else
 		self:UnregisterEvent('UNIT_POWER_UPDATE', Path)
 		self:UnregisterEvent('UNIT_MAXPOWER', Path)
 
 		element:Hide()
-		Path(self, event, unit, 'ALTERNATE')
+		Path(self, event, unit, ALTERNATE_POWER_NAME)
 	end
 end
 
@@ -135,7 +230,7 @@ local function VisibilityPath(self, ...)
 	* event - the event triggering the update (string)
 	* unit  - the unit accompanying the event (string)
 	--]]
-	return (self.AlternativePower.OverrideVisibility or Visibility)(self, ...)
+	return (self.AlternativePower.OverrideVisibility or Visibility) (self, ...)
 end
 
 local function ForceUpdate(element)
@@ -151,8 +246,9 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_POWER_BAR_SHOW', VisibilityPath)
 		self:RegisterEvent('UNIT_POWER_BAR_HIDE', VisibilityPath)
 
-		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
-			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
+		if(element:IsObjectType('StatusBar')) then
+			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
+			element:SetStatusBarTexture(element.texture)
 		end
 
 		if(element:IsMouseEnabled()) then

--- a/elements/alternativepower.lua
+++ b/elements/alternativepower.lua
@@ -114,7 +114,15 @@ local function UpdateColor(self, event, unit, powerType)
 		end
 	end
 
+	--[[ Callback: AlternativePower:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
 
+	* self - the AlternativePower element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(unit, r, g, b)
 	end

--- a/elements/alternativepower.lua
+++ b/elements/alternativepower.lua
@@ -87,8 +87,8 @@ local function UpdateColor(self, event, unit, powerType)
 		t =  self.colors.threat[UnitThreatSituation('player', unit)]
 	elseif(element.colorPower) then
 		t = self.colors.power[ALTERNATE_POWER_INDEX]
-	elseif(element.colorClass and UnitIsPlayer(unit)) or
-		(element.colorClassNPC and not UnitIsPlayer(unit)) then
+	elseif(element.colorClass and UnitIsPlayer(unit))
+		or (element.colorClassNPC and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = self.colors.class[class]
 	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -80,11 +80,10 @@ local function UpdateColor(element, powerType)
 		end
 	end
 
-	--[[ Callback: ClassPower:PostUpdateColor(unit, r, g, b)
+	--[[ Callback: ClassPower:PostUpdateColor(r, g, b)
 	Called after the element color has been updated.
 
 	* self - the ClassPower element
-	* unit - the unit for which the update has been triggered (string)
 	* r    - the red component of the used color (number)[0-1]
 	* g    - the green component of the used color (number)[0-1]
 	* b    - the blue component of the used color (number)[0-1]

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -79,6 +79,10 @@ local function UpdateColor(element, powerType)
 			bg:SetVertexColor(r * mu, g * mu, b * mu)
 		end
 	end
+
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(r, g, b)
+	end
 end
 
 local function Update(self, event, unit, powerType)

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -312,7 +312,7 @@ local function Enable(self, unit)
 		for i = 1, #element do
 			local bar = element[i]
 			if(bar:IsObjectType('StatusBar')) then
-				if(not bar:GetStatusBarTexture()) then
+				if(not (bar:GetStatusBarTexture() or bar:GetStatusBarAtlas())) then
 					bar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 				end
 

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -80,6 +80,15 @@ local function UpdateColor(element, powerType)
 		end
 	end
 
+	--[[ Callback: ClassPower:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
+
+	* self - the ClassPower element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(r, g, b)
 	end

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -97,9 +97,9 @@ local function UpdateColor(self, event, unit)
 		t = self.colors.tapped
 	elseif(element.colorThreat and not UnitPlayerControlled(unit) and UnitThreatSituation('player', unit)) then
 		t =  self.colors.threat[UnitThreatSituation('player', unit)]
-	elseif(element.colorClass and UnitIsPlayer(unit)) or
-		(element.colorClassNPC and not UnitIsPlayer(unit)) or
-		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
+	elseif(element.colorClass and UnitIsPlayer(unit))
+		or (element.colorClassNPC and not UnitIsPlayer(unit))
+		or (element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = self.colors.class[class]
 	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -301,7 +301,7 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_HEALTH', Path)
 		self:RegisterEvent('UNIT_MAXHEALTH', Path)
 
-		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
+		if(element:IsObjectType('StatusBar') and not (element:GetStatusBarTexture() or element:GetStatusBarAtlas())) then
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 		end
 

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -23,8 +23,10 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.
 
-.colorTapping      - Use `self.colors.tapping` to color the bar if the unit isn't tapped by the player (boolean)
 .colorDisconnected - Use `self.colors.disconnected` to color the bar if the unit is offline (boolean)
+.colorTapping      - Use `self.colors.tapping` to color the bar if the unit isn't tapped by the player (boolean)
+.colorThreat       - Use `self.colors.threat[threat]` to color the bar based on the unit's threat status. `threat` is
+                     defined by the first return of [UnitThreatSituation](https://wow.gamepedia.com/API_UnitThreatSituation) (boolean)
 .colorClass        - Use `self.colors.class[class]` to color the bar based on unit class. `class` is defined by the
                      second return of [UnitClass](http://wowprogramming.com/docs/api/UnitClass.html) (boolean)
 .colorClassNPC     - Use `self.colors.class[class]` to color the bar if the unit is a NPC (boolean)
@@ -74,7 +76,7 @@ The following options are listed by priority. The first check that returns true 
     Background.multiplier = .5
 
     -- Register it with oUF
-	Health.bg = Background
+    Health.bg = Background
     self.Health = Health
 --]]
 
@@ -84,34 +86,37 @@ local Private = oUF.Private
 
 local unitSelectionType = Private.unitSelectionType
 
-local function UpdateColor(element, unit, cur, max)
-	local parent = element.__owner
+local function UpdateColor(self, event, unit)
+	if(not unit or self.unit ~= unit) then return end
+	local element = self.Health
 
 	local r, g, b, t
-	if(element.colorTapping and not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)) then
-		t = parent.colors.tapped
-	elseif(element.colorDisconnected and element.disconnected) then
-		t = parent.colors.disconnected
+	if(element.colorDisconnected and element.disconnected) then
+		t = self.colors.disconnected
+	elseif(element.colorTapping and not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)) then
+		t = self.colors.tapped
+	elseif(element.colorThreat and not UnitPlayerControlled(unit) and UnitThreatSituation('player', unit)) then
+		t =  self.colors.threat[UnitThreatSituation('player', unit)]
 	elseif(element.colorClass and UnitIsPlayer(unit)) or
 		(element.colorClassNPC and not UnitIsPlayer(unit)) or
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
-		t = parent.colors.class[class]
+		t = self.colors.class[class]
 	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then
-		t = parent.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
+		t = self.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
-		t = parent.colors.reaction[UnitReaction(unit, 'player')]
+		t = self.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then
-		r, g, b = parent:ColorGradient(cur, max, unpack(element.smoothGradient or parent.colors.smooth))
+		r, g, b = self:ColorGradient(element.cur or 1, element.max or 1, unpack(element.smoothGradient or self.colors.smooth))
 	elseif(element.colorHealth) then
-		t = parent.colors.health
+		t = self.colors.health
 	end
 
 	if(t) then
 		r, g, b = t[1], t[2], t[3]
 	end
 
-	if(r or g or b) then
+	if(b) then
 		element:SetStatusBarColor(r, g, b)
 
 		local bg = element.bg
@@ -120,6 +125,21 @@ local function UpdateColor(element, unit, cur, max)
 			bg:SetVertexColor(r * mu, g * mu, b * mu)
 		end
 	end
+
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(unit, r, g, b)
+	end
+end
+
+local function ColorPath(self, ...)
+	--[[ Override: Health.UpdateColor(self, event, unit)
+	Used to completely override the internal function for updating the widgets' colors.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* unit  - the unit accompanying the event (string)
+	--]]
+	(self.Health.UpdateColor or UpdateColor) (self, ...)
 end
 
 local function Update(self, event, unit)
@@ -137,26 +157,18 @@ local function Update(self, event, unit)
 	end
 
 	local cur, max = UnitHealth(unit), UnitHealthMax(unit)
-	local disconnected = not UnitIsConnected(unit)
 	element:SetMinMaxValues(0, max)
 
+	local disconnected = not UnitIsConnected(unit)
 	if(disconnected) then
 		element:SetValue(max)
 	else
 		element:SetValue(cur)
 	end
 
+	element.cur = cur
+	element.max = max
 	element.disconnected = disconnected
-
-	--[[ Override: Health:UpdateColor(unit, cur, max)
-	Used to completely override the internal function for updating the widgets' colors.
-
-	* self - the Health element
-	* unit - the unit for which the update has been triggered (string)
-	* cur  - the unit's current health value (number)
-	* max  - the unit's maximum possible health value (number)
-	--]]
-	element:UpdateColor(unit, cur, max)
 
 	--[[ Callback: Health:PostUpdate(unit, cur, max)
 	Called after the element has been updated.
@@ -167,7 +179,7 @@ local function Update(self, event, unit)
 	* max  - the unit's maximum possible health value (number)
 	--]]
 	if(element.PostUpdate) then
-		return element:PostUpdate(unit, cur, max)
+		element:PostUpdate(unit, cur, max)
 	end
 end
 
@@ -179,11 +191,85 @@ local function Path(self, ...)
 	* event - the event triggering the update (string)
 	* unit  - the unit accompanying the event (string)
 	--]]
-	return (self.Health.Override or Update) (self, ...)
+	(self.Health.Override or Update) (self, ...);
+
+	ColorPath(self, ...)
 end
 
 local function ForceUpdate(element)
-	return Path(element.__owner, 'ForceUpdate', element.__owner.unit)
+	Path(element.__owner, 'ForceUpdate', element.__owner.unit)
+end
+
+--[[ Health:SetColorDisconnected(state, isForced)
+Used to toggle coloring if the unit is offline.
+
+* self     - the Health element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorDisconnected(element, state, isForced)
+	if(element.colorDisconnected ~= state or isForced) then
+		element.colorDisconnected = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_CONNECTION', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_CONNECTION', ColorPath)
+		end
+	end
+end
+
+--[[ Health:SetColorSelection(state, isForced)
+Used to toggle coloring by the unit's selection.
+
+* self     - the Health element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorSelection(element, state, isForced)
+	if(element.colorSelection ~= state or isForced) then
+		element.colorSelection = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_FLAGS', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_FLAGS', ColorPath)
+		end
+	end
+end
+
+--[[ Health:SetColorTapping(state, isForced)
+Used to toggle coloring if the unit isn't tapped by the player.
+
+* self     - the Health element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorTapping(element, state, isForced)
+	if(element.colorTapping ~= state or isForced) then
+		element.colorTapping = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_FACTION', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_FACTION', ColorPath)
+		end
+	end
+end
+
+--[[ Health:SetColorThreat(state, isForced)
+Used to toggle coloring by the unit's threat status.
+
+* self     - the Health element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorThreat(element, state, isForced)
+	if(element.colorThreat ~= state or isForced) then
+		element.colorThreat = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
+		end
+	end
 end
 
 local function Enable(self, unit)
@@ -191,19 +277,32 @@ local function Enable(self, unit)
 	if(element) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
+		element.SetColorDisconnected = SetColorDisconnected
+		element.SetColorSelection = SetColorSelection
+		element.SetColorTapping = SetColorTapping
+		element.SetColorThreat = SetColorThreat
+
+		if(element.colorDisconnected) then
+			self:RegisterEvent('UNIT_CONNECTION', ColorPath)
+		end
+
+		if(element.colorSelection) then
+			self:RegisterEvent('UNIT_FLAGS', ColorPath)
+		end
+
+		if(element.colorTapping) then
+			self:RegisterEvent('UNIT_FACTION', ColorPath)
+		end
+
+		if(element.colorThreat) then
+			self:RegisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
+		end
 
 		self:RegisterEvent('UNIT_HEALTH', Path)
 		self:RegisterEvent('UNIT_MAXHEALTH', Path)
-		self:RegisterEvent('UNIT_CONNECTION', Path)
-		self:RegisterEvent('UNIT_FACTION', Path) -- For tapping
-		self:RegisterEvent('UNIT_FLAGS', Path) -- For selection
 
 		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
-		end
-
-		if(not element.UpdateColor) then
-			element.UpdateColor = UpdateColor
 		end
 
 		element:Show()
@@ -219,9 +318,10 @@ local function Disable(self)
 
 		self:UnregisterEvent('UNIT_HEALTH', Path)
 		self:UnregisterEvent('UNIT_MAXHEALTH', Path)
-		self:UnregisterEvent('UNIT_CONNECTION', Path)
-		self:UnregisterEvent('UNIT_FACTION', Path)
-		self:UnregisterEvent('UNIT_FLAGS', Path)
+		self:UnregisterEvent('UNIT_CONNECTION', ColorPath)
+		self:UnregisterEvent('UNIT_FACTION', ColorPath)
+		self:UnregisterEvent('UNIT_FLAGS', ColorPath)
+		self:UnregisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
 	end
 end
 

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -126,6 +126,15 @@ local function UpdateColor(self, event, unit)
 		end
 	end
 
+	--[[ Callback: Health:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
+
+	* self - the Health element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(unit, r, g, b)
 	end

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -135,9 +135,9 @@ local function UpdateColor(self, event, unit)
 		else
 			t = self.colors.power[ALTERNATE_POWER_INDEX]
 		end
-	elseif(element.colorClass and UnitIsPlayer(unit)) or
-		(element.colorClassNPC and not UnitIsPlayer(unit)) or
-		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
+	elseif(element.colorClass and UnitIsPlayer(unit))
+		or (element.colorClassNPC and not UnitIsPlayer(unit))
+		or (element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = self.colors.class[class]
 	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -99,8 +99,18 @@ local unitSelectionType = Private.unitSelectionType
 -- sourced from FrameXML/UnitPowerBarAlt.lua
 local ALTERNATE_POWER_INDEX = Enum.PowerType.Alternate or 10
 
-local function GetDisplayPower(self)
-	local unit = self.__owner.unit
+--[[ Override: Power:GetDisplayPower()
+Used to get info on the unit's alternative power, if any.
+Should return the power type index (see [Enum.PowerType.Alternate](https://wow.gamepedia.com/Enum_Unit.PowerType))
+and the minimum value for the given power type (see [info.minPower](https://wow.gamepedia.com/API_GetUnitPowerBarInfo))
+or nil if the unit has no alternative (alternate) power or it should not be
+displayed. In case of a nil return, the element defaults to the primary power
+type and zero for the minimum value.
+
+* self - the Power element
+--]]
+local function GetDisplayPower(element)
+	local unit = element.__owner.unit
 	local barInfo = GetUnitPowerBarInfo(unit)
 	if(barInfo and barInfo.showOnRaid and (UnitInParty(unit) or UnitInRaid(unit))) then
 		return ALTERNATE_POWER_INDEX, barInfo.minPower
@@ -165,6 +175,15 @@ local function UpdateColor(self, event, unit)
 		end
 	end
 
+	--[[ Callback: Power:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
+
+	* self - the Power element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(unit, r, g, b)
 	end
@@ -382,11 +401,6 @@ local function Enable(self)
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 		end
 
-		--[[ Override: Power:GetDisplayPower()
-		Used to get info on the unit's alternative power, if any.
-
-		* self - the Power element
-		--]]
 		if(not element.GetDisplayPower) then
 			element.GetDisplayPower = GetDisplayPower
 		end

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -21,8 +21,6 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
                                     bar (boolean)
 .displayAltPower                  - Use this to let the widget display alternate power if the unit has one. If no
                                     alternate power the display will fall back to primary power (boolean)
-.useAtlas                         - Use this to let the widget use an atlas for its texture if an atlas is present in
-                                    `self.colors.power` for the appropriate power type (boolean)
 .smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
 .considerSelectionInCombatHostile - Indicates whether selection should be considered hostile while the unit is in
                                     combat with the player (boolean)
@@ -113,7 +111,7 @@ local function UpdateColor(self, event, unit)
 
 	local ptype, ptoken, altR, altG, altB = UnitPowerType(unit)
 
-	local r, g, b, t, atlas
+	local r, g, b, t
 	if(element.colorDisconnected and element.disconnected) then
 		t = self.colors.disconnected
 	elseif(element.colorTapping and not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)) then
@@ -137,10 +135,6 @@ local function UpdateColor(self, event, unit)
 		else
 			t = self.colors.power[ALTERNATE_POWER_INDEX]
 		end
-
-		if(element.useAtlas and t and t.atlas) then
-			atlas = t.atlas
-		end
 	elseif(element.colorClass and UnitIsPlayer(unit)) or
 		(element.colorClassNPC and not UnitIsPlayer(unit)) or
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
@@ -159,25 +153,18 @@ local function UpdateColor(self, event, unit)
 		r, g, b = t[1], t[2], t[3]
 	end
 
-	if(atlas) then
-		element:SetStatusBarAtlas(atlas)
-		element:SetStatusBarColor(1, 1, 1)
-	else
-		element:SetStatusBarTexture(element.texture)
+	if(b) then
+		element:SetStatusBarColor(r, g, b)
 
-		if(b) then
-			element:SetStatusBarColor(r, g, b)
+		local bg = element.bg
+		if(bg) then
+			local mu = bg.multiplier or 1
+			bg:SetVertexColor(r * mu, g * mu, b * mu)
 		end
 	end
 
-	local bg = element.bg
-	if(bg and b) then
-		local mu = bg.multiplier or 1
-		bg:SetVertexColor(r * mu, g * mu, b * mu)
-	end
-
 	if(element.PostUpdateColor) then
-		element:PostUpdateColor(unit, r, g, b, atlas)
+		element:PostUpdateColor(unit, r, g, b)
 	end
 end
 
@@ -389,9 +376,8 @@ local function Enable(self)
 		self:RegisterEvent('UNIT_POWER_BAR_HIDE', Path)
 		self:RegisterEvent('UNIT_POWER_BAR_SHOW', Path)
 
-		if(element:IsObjectType('StatusBar')) then
-			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
-			element:SetStatusBarTexture(element.texture)
+		if(element:IsObjectType('StatusBar') and not (element:GetStatusBarTexture() or element:GetStatusBarAtlas())) then
+			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 		end
 
 		element:Show()

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -175,8 +175,9 @@ local function UpdateColor(self, event, unit)
 		local mu = bg.multiplier or 1
 		bg:SetVertexColor(r * mu, g * mu, b * mu)
 	end
+
 	if(element.PostUpdateColor) then
-		element:PostUpdateColor(unit, r, g, b)
+		element:PostUpdateColor(unit, r, g, b, atlas)
 	end
 end
 

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -18,23 +18,21 @@ A default texture will be applied if the widget is a StatusBar and doesn't have 
 ## Options
 
 .frequentUpdates                  - Indicates whether to use UNIT_POWER_FREQUENT instead UNIT_POWER_UPDATE to update the
-                                    bar. Only valid for the player and pet units (boolean)
+                                    bar (boolean)
 .displayAltPower                  - Use this to let the widget display alternate power if the unit has one. If no
                                     alternate power the display will fall back to primary power (boolean)
-.useAtlas                         - Use this to let the widget use an atlas for its texture if `.atlas` is defined on
-                                    the widget or an atlas is present in `self.colors.power` for the appropriate power
-                                    type (boolean)
-.atlas                            - A custom atlas (string)
+.useAtlas                         - Use this to let the widget use an atlas for its texture if an atlas is present in
+                                    `self.colors.power` for the appropriate power type (boolean)
 .smoothGradient                   - 9 color values to be used with the .colorSmooth option (table)
 .considerSelectionInCombatHostile - Indicates whether selection should be considered hostile while the unit is in
                                     combat with the player (boolean)
 
 The following options are listed by priority. The first check that returns true decides the color of the bar.
 
-.colorTapping      - Use `self.colors.tapping` to color the bar if the unit isn't tapped by the player (boolean)
 .colorDisconnected - Use `self.colors.disconnected` to color the bar if the unit is offline (boolean)
-.altPowerColor     - The RGB values to use for a fixed color if the alt power bar is being displayed instead of primary
-                     power bar (table)
+.colorTapping      - Use `self.colors.tapping` to color the bar if the unit isn't tapped by the player (boolean)
+.colorThreat       - Use `self.colors.threat[threat]` to color the bar based on the unit's threat status. `threat` is
+                     defined by the first return of [UnitThreatSituation](https://wow.gamepedia.com/API_UnitThreatSituation) (boolean)
 .colorPower        - Use `self.colors.power[token]` to color the bar based on the unit's power type. This method will
                      fall-back to `:GetAlternativeColor()` if it can't find a color matching the token. If this function
                      isn't defined, then it will attempt to color based upon the alternative power colors returned by
@@ -62,7 +60,6 @@ The following options are listed by priority. The first check that returns true 
 ## Attributes
 
 .disconnected - Indicates whether the unit is disconnected (boolean)
-.tapped       - Indicates whether the unit is tapped by the player (boolean)
 
 ## Examples
 
@@ -90,7 +87,7 @@ The following options are listed by priority. The first check that returns true 
     Background.multiplier = .5
 
     -- Register it with oUF
-	Power.bg = Background
+    Power.bg = Background
     self.Power = Power
 --]]
 
@@ -110,70 +107,65 @@ local function getDisplayPower(unit)
 	end
 end
 
-local function UpdateColor(element, unit, cur, min, max, displayType)
-	local parent = element.__owner
+local function UpdateColor(self, event, unit)
+	if(self.unit ~= unit) then return end
+	local element = self.Power
+
 	local ptype, ptoken, altR, altG, altB = UnitPowerType(unit)
 
-	local r, g, b, t
-	if(element.colorTapping and element.tapped) then
-		t = parent.colors.tapped
-	elseif(element.colorDisconnected and element.disconnected) then
-		t = parent.colors.disconnected
-	elseif(displayType == ALTERNATE_POWER_INDEX and element.altPowerColor) then
-		t = element.altPowerColor
+	local r, g, b, t, atlas
+	if(element.colorDisconnected and element.disconnected) then
+		t = self.colors.disconnected
+	elseif(element.colorTapping and not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)) then
+		t = self.colors.tapped
+	elseif(element.colorThreat and not UnitPlayerControlled(unit) and UnitThreatSituation('player', unit)) then
+		t =  self.colors.threat[UnitThreatSituation('player', unit)]
 	elseif(element.colorPower) then
-		t = parent.colors.power[ptoken]
-		if(not t) then
-			if(element.GetAlternativeColor) then
-				r, g, b = element:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
-			elseif(altR) then
-				r, g, b = altR, altG, altB
-
-				if(r > 1 or g > 1 or b > 1) then
-					-- BUG: As of 7.0.3, altR, altG, altB may be in 0-1 or 0-255 range.
-					r, g, b = r / 255, g / 255, b / 255
+		if(element.displayType ~= ALTERNATE_POWER_INDEX) then
+			t = self.colors.power[ptoken or ptype]
+			if(not t) then
+				if(element.GetAlternativeColor) then
+					r, g, b = element:GetAlternativeColor(unit, ptype, ptoken, altR, altG, altB)
+				elseif(altR) then
+					r, g, b = altR, altG, altB
+					if(r > 1 or g > 1 or b > 1) then
+						-- BUG: As of 7.0.3, altR, altG, altB may be in 0-1 or 0-255 range.
+						r, g, b = r / 255, g / 255, b / 255
+					end
 				end
-			else
-				t = parent.colors.power[ptype]
 			end
+		else
+			t = self.colors.power[ALTERNATE_POWER_INDEX]
+		end
+
+		if(element.useAtlas and t and t.atlas) then
+			atlas = t.atlas
 		end
 	elseif(element.colorClass and UnitIsPlayer(unit)) or
 		(element.colorClassNPC and not UnitIsPlayer(unit)) or
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
-		t = parent.colors.class[class]
+		t = self.colors.class[class]
 	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then
-		t = parent.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
+		t = self.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
-		t = parent.colors.reaction[UnitReaction(unit, 'player')]
+		t = self.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then
-		local adjust = 0 - (min or 0)
-		r, g, b = parent:ColorGradient(cur + adjust, max + adjust, unpack(element.smoothGradient or parent.colors.smooth))
+		local adjust = 0 - (element.min or 0)
+		r, g, b = self:ColorGradient((element.cur or 1) + adjust, (element.max or 1) + adjust, unpack(element.smoothGradient or self.colors.smooth))
 	end
 
 	if(t) then
 		r, g, b = t[1], t[2], t[3]
 	end
 
-	t = parent.colors.power[ptoken or ptype]
-
-	local atlas = element.atlas or (t and t.atlas)
-	if(element.useAtlas and atlas and displayType ~= ALTERNATE_POWER_INDEX) then
+	if(atlas) then
 		element:SetStatusBarAtlas(atlas)
 		element:SetStatusBarColor(1, 1, 1)
-
-		if(element.colorTapping or element.colorDisconnected) then
-			t = element.disconnected and parent.colors.disconnected or parent.colors.tapped
-			element:GetStatusBarTexture():SetDesaturated(element.disconnected or element.tapped)
-		end
-
-		if(t and (r or g or b)) then
-			r, g, b = t[1], t[2], t[3]
-		end
 	else
 		element:SetStatusBarTexture(element.texture)
 
-		if(r or g or b) then
+		if(b) then
 			element:SetStatusBarColor(r, g, b)
 		end
 	end
@@ -183,6 +175,20 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		local mu = bg.multiplier or 1
 		bg:SetVertexColor(r * mu, g * mu, b * mu)
 	end
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(unit, r, g, b)
+	end
+end
+
+local function ColorPath(self, ...)
+	--[[ Override: Power.UpdateColor(self, event, unit)
+	Used to completely override the internal function for updating the widgets' colors.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* unit  - the unit accompanying the event (string)
+	--]]
+	(self.Power.UpdateColor or UpdateColor) (self, ...)
 end
 
 local function Update(self, event, unit)
@@ -205,42 +211,32 @@ local function Update(self, event, unit)
 	end
 
 	local cur, max = UnitPower(unit, displayType), UnitPowerMax(unit, displayType)
-	local disconnected = not UnitIsConnected(unit)
-	local tapped = not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)
 	element:SetMinMaxValues(min or 0, max)
 
+	local disconnected = not UnitIsConnected(unit)
 	if(disconnected) then
 		element:SetValue(max)
 	else
 		element:SetValue(cur)
 	end
 
+	element.cur = cur
+	element.min = min
+	element.max = max
+	element.displayType = displayType
 	element.disconnected = disconnected
-	element.tapped = tapped
-
-	--[[ Override: Power:UpdateColor(unit, cur, min, max, displayType)
-	Used to completely override the internal function for updating the widget's colors.
-
-	* self        - the Power element
-	* unit        - the unit for which the update has been triggered (string)
-	* cur         - the unit's current power value (number)
-	* min         - the unit's minimum possible power value (number)
-	* max         - the unit's maximum possible power value (number)
-	* displayType - the alternative power display type if applicable (number?)[Enum.PowerType.Alternate]
-	--]]
-	element:UpdateColor(unit, cur, min, max, displayType)
 
 	--[[ Callback: Power:PostUpdate(unit, cur, min, max)
 	Called after the element has been updated.
 
-	* self       - the Power element
-	* unit       - the unit for which the update has been triggered (string)
-	* cur        - the unit's current power value (number)
-	* min        - the unit's minimum possible power value (number)
-	* max        - the unit's maximum possible power value (number)
+	* self - the Power element
+	* unit - the unit for which the update has been triggered (string)
+	* cur  - the unit's current power value (number)
+	* min  - the unit's minimum possible power value (number)
+	* max  - the unit's maximum possible power value (number)
 	--]]
 	if(element.PostUpdate) then
-		return element:PostUpdate(unit, cur, min, max)
+		element:PostUpdate(unit, cur, min, max)
 	end
 end
 
@@ -253,23 +249,98 @@ local function Path(self, ...)
 	* unit  - the unit accompanying the event (string)
 	* ...   - the arguments accompanying the event
 	--]]
-	return (self.Power.Override or Update) (self, ...)
+	(self.Power.Override or Update) (self, ...);
+
+	ColorPath(self, ...)
 end
 
 local function ForceUpdate(element)
-	return Path(element.__owner, 'ForceUpdate', element.__owner.unit)
+	Path(element.__owner, 'ForceUpdate', element.__owner.unit)
 end
 
---[[ Power:SetFrequentUpdates(state)
+--[[ Power:SetColorDisconnected(state, isForced)
+Used to toggle coloring if the unit is offline.
+
+* self     - the Power element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorDisconnected(element, state, isForced)
+	if(element.colorDisconnected ~= state or isForced) then
+		element.colorDisconnected = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_CONNECTION', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_CONNECTION', ColorPath)
+		end
+	end
+end
+
+--[[ Power:SetColorSelection(state, isForced)
+Used to toggle coloring by the unit's selection.
+
+* self     - the Power element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorSelection(element, state, isForced)
+	if(element.colorSelection ~= state or isForced) then
+		element.colorSelection = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_FLAGS', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_FLAGS', ColorPath)
+		end
+	end
+end
+
+--[[ Power:SetColorTapping(state, isForced)
+Used to toggle coloring if the unit isn't tapped by the player.
+
+* self     - the Power element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorTapping(element, state, isForced)
+	if(element.colorTapping ~= state or isForced) then
+		element.colorTapping = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_FACTION', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_FACTION', ColorPath)
+		end
+	end
+end
+
+--[[ Power:SetColorThreat(state, isForced)
+Used to toggle coloring by the unit's threat status.
+
+* self     - the Power element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
+--]]
+local function SetColorThreat(element, state, isForced)
+	if(element.colorThreat ~= state or isForced) then
+		element.colorThreat = state
+		if(state) then
+			element.__owner:RegisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
+		else
+			element.__owner:UnregisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
+		end
+	end
+end
+
+--[[ Power:SetFrequentUpdates(state, isForced)
 Used to toggle frequent updates.
 
-* self  - the Power element
-* state - the desired state of frequent updates (boolean)
+* self     - the Power element
+* state    - the desired state (boolean)
+* isForced - forces the event update even if the state wasn't changed (boolean)
 --]]
-local function SetFrequentUpdates(element, state)
-	if(element.frequentUpdates ~= state) then
+local function SetFrequentUpdates(element, state, isForced)
+	if(element.frequentUpdates ~= state or isForced) then
 		element.frequentUpdates = state
-		if(element.frequentUpdates) then
+		if(state) then
 			element.__owner:UnregisterEvent('UNIT_POWER_UPDATE', Path)
 			element.__owner:RegisterEvent('UNIT_POWER_FREQUENT', Path)
 		else
@@ -284,7 +355,27 @@ local function Enable(self)
 	if(element) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
+		element.SetColorDisconnected = SetColorDisconnected
+		element.SetColorSelection = SetColorSelection
+		element.SetColorTapping = SetColorTapping
+		element.SetColorThreat = SetColorThreat
 		element.SetFrequentUpdates = SetFrequentUpdates
+
+		if(element.colorDisconnected) then
+			self:RegisterEvent('UNIT_CONNECTION', ColorPath)
+		end
+
+		if(element.colorSelection) then
+			self:RegisterEvent('UNIT_FLAGS', ColorPath)
+		end
+
+		if(element.colorTapping) then
+			self:RegisterEvent('UNIT_FACTION', ColorPath)
+		end
+
+		if(element.colorThreat) then
+			self:RegisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
+		end
 
 		if(element.frequentUpdates) then
 			self:RegisterEvent('UNIT_POWER_FREQUENT', Path)
@@ -292,21 +383,14 @@ local function Enable(self)
 			self:RegisterEvent('UNIT_POWER_UPDATE', Path)
 		end
 
-		self:RegisterEvent('UNIT_POWER_BAR_SHOW', Path)
-		self:RegisterEvent('UNIT_POWER_BAR_HIDE', Path)
 		self:RegisterEvent('UNIT_DISPLAYPOWER', Path)
-		self:RegisterEvent('UNIT_CONNECTION', Path)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)
-		self:RegisterEvent('UNIT_FACTION', Path) -- For tapping
-		self:RegisterEvent('UNIT_FLAGS', Path) -- For selection
+		self:RegisterEvent('UNIT_POWER_BAR_HIDE', Path)
+		self:RegisterEvent('UNIT_POWER_BAR_SHOW', Path)
 
 		if(element:IsObjectType('StatusBar')) then
 			element.texture = element:GetStatusBarTexture() and element:GetStatusBarTexture():GetTexture() or [[Interface\TargetingFrame\UI-StatusBar]]
 			element:SetStatusBarTexture(element.texture)
-		end
-
-		if(not element.UpdateColor) then
-			element.UpdateColor = UpdateColor
 		end
 
 		element:Show()
@@ -320,15 +404,16 @@ local function Disable(self)
 	if(element) then
 		element:Hide()
 
+		self:UnregisterEvent('UNIT_DISPLAYPOWER', Path)
+		self:UnregisterEvent('UNIT_MAXPOWER', Path)
+		self:UnregisterEvent('UNIT_POWER_BAR_HIDE', Path)
+		self:UnregisterEvent('UNIT_POWER_BAR_SHOW', Path)
 		self:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
 		self:UnregisterEvent('UNIT_POWER_UPDATE', Path)
-		self:UnregisterEvent('UNIT_POWER_BAR_SHOW', Path)
-		self:UnregisterEvent('UNIT_POWER_BAR_HIDE', Path)
-		self:UnregisterEvent('UNIT_DISPLAYPOWER', Path)
-		self:UnregisterEvent('UNIT_CONNECTION', Path)
-		self:UnregisterEvent('UNIT_MAXPOWER', Path)
-		self:UnregisterEvent('UNIT_FACTION', Path)
-		self:UnregisterEvent('UNIT_FLAGS', Path)
+		self:UnregisterEvent('UNIT_CONNECTION', ColorPath)
+		self:UnregisterEvent('UNIT_FACTION', ColorPath)
+		self:UnregisterEvent('UNIT_FLAGS', ColorPath)
+		self:UnregisterEvent('UNIT_THREAT_LIST_UPDATE', ColorPath)
 	end
 end
 

--- a/elements/powerprediction.lua
+++ b/elements/powerprediction.lua
@@ -148,13 +148,15 @@ local function Enable(self)
 		self:RegisterEvent('UNIT_DISPLAYPOWER', Path)
 
 		if(element.mainBar) then
-			if(element.mainBar:IsObjectType('StatusBar') and not element.mainBar:GetStatusBarTexture()) then
+			if(element.mainBar:IsObjectType('StatusBar')
+				and not (element.mainBar:GetStatusBarTexture() or element.mainBar:GetStatusBarAtlas())) then
 				element.mainBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 			end
 		end
 
 		if(element.altBar) then
-			if(element.altBar:IsObjectType('StatusBar') and not element.altBar:GetStatusBarTexture()) then
+			if(element.altBar:IsObjectType('StatusBar')
+				and not (element.altBar:GetStatusBarTexture() or element.altBar:GetStatusBarAtlas())) then
 				element.altBar:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 			end
 		end

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -104,11 +104,10 @@ local function UpdateColor(self, event)
 		end
 	end
 
-	--[[ Callback: Runes:PostUpdateColor(unit, r, g, b)
+	--[[ Callback: Runes:PostUpdateColor(r, g, b)
 	Called after the element color has been updated.
 
 	* self - the Runes element
-	* unit - the unit for which the update has been triggered (string)
 	* r    - the red component of the used color (number)[0-1]
 	* g    - the green component of the used color (number)[0-1]
 	* b    - the blue component of the used color (number)[0-1]

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -189,9 +189,14 @@ local function Path(self, ...)
 	(self.Runes.Override or Update) (self, ...)
 end
 
-local function ForceUpdate(element, event, ...)
-	Path(element.__owner, event or 'ForceUpdate', ...)
-	ColorPath(element.__owner, event or 'ForceUpdate', ...)
+local function AllPath(...)
+	Path(...)
+	ColorPath(...)
+end
+
+local function ForceUpdate(element)
+	Path(element.__owner, 'ForceUpdate')
+	ColorPath(element.__owner, 'ForceUpdate')
 end
 
 local function Enable(self, unit)
@@ -226,4 +231,4 @@ local function Disable(self)
 	end
 end
 
-oUF:AddElement('Runes', ForceUpdate, Enable, Disable)
+oUF:AddElement('Runes', AllPath, Enable, Disable)

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -104,6 +104,15 @@ local function UpdateColor(self, event)
 		end
 	end
 
+	--[[ Callback: Runes:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
+
+	* self - the Runes element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(r, g, b)
 	end

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -180,9 +180,9 @@ local function Path(self, ...)
 	(self.Runes.Override or Update) (self, ...)
 end
 
-local function ForceUpdate(element)
-	Path(element.__owner, 'ForceUpdate')
-	ColorPath(element.__owner, 'ForceUpdate')
+local function ForceUpdate(element, event, ...)
+	Path(element.__owner, event or 'ForceUpdate', ...)
+	ColorPath(element.__owner, event or 'ForceUpdate', ...)
 end
 
 local function Enable(self, unit)
@@ -217,4 +217,4 @@ local function Disable(self)
 	end
 end
 
-oUF:AddElement('Runes', Path, Enable, Disable)
+oUF:AddElement('Runes', ForceUpdate, Enable, Disable)

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -86,7 +86,7 @@ local function UpdateColor(self, event)
 	local spec = GetSpecialization() or 0
 
 	local color
-	if(spec  > 0 and spec < 4 and element.colorSpec) then
+	if(spec > 0 and spec < 4 and element.colorSpec) then
 		color = self.colors.runes[spec]
 	else
 		color = self.colors.power.RUNES
@@ -193,7 +193,7 @@ local function Enable(self, unit)
 
 		for i = 1, #element do
 			local rune = element[i]
-			if(rune:IsObjectType('StatusBar') and not rune:GetStatusBarTexture()) then
+			if(rune:IsObjectType('StatusBar') and not (rune:GetStatusBarTexture() or rune:GetStatusBarAtlas())) then
 				rune:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 			end
 		end

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -80,25 +80,44 @@ local function descSort(runeAID, runeBID)
 	end
 end
 
-local function UpdateColor(element, runeID)
+local function UpdateColor(self, event)
+	local element = self.Runes
+
 	local spec = GetSpecialization() or 0
 
 	local color
-	if(spec > 0 and spec < 4 and element.colorSpec) then
-		color = element.__owner.colors.runes[spec]
+	if(spec  > 0 and spec < 4 and element.colorSpec) then
+		color = self.colors.runes[spec]
 	else
-		color = element.__owner.colors.power.RUNES
+		color = self.colors.power.RUNES
 	end
 
 	local r, g, b = color[1], color[2], color[3]
 
-	element[runeID]:SetStatusBarColor(r, g, b)
+	for index = 1, #element do
+		element[index]:SetStatusBarColor(r, g, b)
 
-	local bg = element[runeID].bg
-	if(bg) then
-		local mu = bg.multiplier or 1
-		bg:SetVertexColor(r * mu, g * mu, b * mu)
+		local bg = element[index].bg
+		if(bg) then
+			local mu = bg.multiplier or 1
+			bg:SetVertexColor(r * mu, g * mu, b * mu)
+		end
 	end
+
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(r, g, b)
+	end
+end
+
+local function ColorPath(self, ...)
+	--[[ Override: Runes.UpdateColor(self, event, ...)
+	Used to completely override the internal function for updating the widgets' colors.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* ...   - the arguments accompanying the event
+	--]]
+	(self.Runes.UpdateColor or UpdateColor) (self, ...)
 end
 
 local function Update(self, event)
@@ -150,21 +169,7 @@ local function Update(self, event)
 	end
 end
 
-local function Path(self, event, ...)
-	local element = self.Runes
-	if(event ~= 'RUNE_POWER_UPDATE') then
-		--[[ Override: Runes:UpdateColor(runeID)
-		Used to completely override the internal function for updating the widgets' colors.
-
-		* self   - the Runes element
-		* runeID - the index of the updated rune (number)
-		--]]
-		local UpdateColorMethod = element.UpdateColor or UpdateColor
-		for index = 1, #element do
-			UpdateColorMethod(element, index)
-		end
-	end
-
+local function Path(self, ...)
 	--[[ Override: Runes.Override(self, event, ...)
 	Used to completely override the internal update function.
 
@@ -172,11 +177,12 @@ local function Path(self, event, ...)
 	* event - the event triggering the update (string)
 	* ...   - the arguments accompanying the event
 	--]]
-	return (element.Override or Update) (self, event, ...)
+	(self.Runes.Override or Update) (self, ...)
 end
 
 local function ForceUpdate(element)
-	return Path(element.__owner, 'ForceUpdate')
+	Path(element.__owner, 'ForceUpdate')
+	ColorPath(element.__owner, 'ForceUpdate')
 end
 
 local function Enable(self, unit)
@@ -192,7 +198,7 @@ local function Enable(self, unit)
 			end
 		end
 
-		self:RegisterEvent('PLAYER_SPECIALIZATION_CHANGED', Path)
+		self:RegisterEvent('PLAYER_SPECIALIZATION_CHANGED', ColorPath)
 		self:RegisterEvent('RUNE_POWER_UPDATE', Path, true)
 
 		return true
@@ -206,7 +212,7 @@ local function Disable(self)
 			element[i]:Hide()
 		end
 
-		self:UnregisterEvent('PLAYER_SPECIALIZATION_CHANGED', Path)
+		self:UnregisterEvent('PLAYER_SPECIALIZATION_CHANGED', ColorPath)
 		self:UnregisterEvent('RUNE_POWER_UPDATE', Path)
 	end
 end

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -49,9 +49,12 @@ local STAGGER_GREEN_INDEX = STAGGER_GREEN_INDEX or 1
 local STAGGER_YELLOW_INDEX = STAGGER_YELLOW_INDEX or 2
 local STAGGER_RED_INDEX = STAGGER_RED_INDEX or 3
 
-local function UpdateColor(element, cur, max)
-	local colors = element.__owner.colors.power[BREWMASTER_POWER_BAR_NAME]
-	local perc = cur / max
+local function UpdateColor(self, event, unit)
+	if(unit and unit ~= self.unit) then return end
+	local element = self.Stagger
+
+	local colors = self.colors.power[BREWMASTER_POWER_BAR_NAME]
+	local perc = (element.cur or 0) / (element.max or 1)
 
 	local t
 	if(perc >= STAGGER_RED_TRANSITION) then
@@ -74,6 +77,10 @@ local function UpdateColor(element, cur, max)
 				bg:SetVertexColor(r * mu, g * mu, b * mu)
 			end
 		end
+	end
+
+	if(element.PostUpdateColor) then
+		element:PostUpdateColor(r, g, b)
 	end
 end
 
@@ -98,14 +105,8 @@ local function Update(self, event, unit)
 	element:SetMinMaxValues(0, max)
 	element:SetValue(cur)
 
-	--[[ Override: Stagger:UpdateColor(cur, max)
-	Used to completely override the internal function for updating the widget's colors.
-
-	* self - the Stagger element
-	* cur  - the amount of staggered damage (number)
-	* max  - the player's maximum possible health value (number)
-	--]]
-	element:UpdateColor(cur, max)
+	element.cur = cur
+	element.max = max
 
 	--[[ Callback: Stagger:PostUpdate(cur, max)
 	Called after the element has been updated.
@@ -127,7 +128,16 @@ local function Path(self, ...)
 	* event - the event triggering the update (string)
 	* unit  - the unit accompanying the event (string)
 	--]]
-	return (self.Stagger.Override or Update)(self, ...)
+	(self.Stagger.Override or Update)(self, ...);
+
+	--[[ Override: Stagger.UpdateColor(self, event, unit)
+	Used to completely override the internal function for updating the widgets' colors.
+
+	* self  - the parent object
+	* event - the event triggering the update (string)
+	* unit  - the unit accompanying the event (string)
+	--]]
+	(self.Stagger.UpdateColor or UpdateColor) (self, ...)
 end
 
 local function Visibility(self, event, unit)
@@ -142,7 +152,7 @@ local function Visibility(self, event, unit)
 			self:RegisterEvent('UNIT_AURA', Path)
 		end
 
-		return Path(self, event, unit)
+		Path(self, event, unit)
 	end
 end
 
@@ -154,11 +164,11 @@ local function VisibilityPath(self, ...)
 	* event - the event triggering the update (string)
 	* unit  - the unit accompanying the event (string)
 	--]]
-	return (self.Stagger.OverrideVisibility or Visibility)(self, ...)
+	(self.Stagger.OverrideVisibility or Visibility)(self, ...)
 end
 
 local function ForceUpdate(element)
-	return VisibilityPath(element.__owner, 'ForceUpdate', element.__owner.unit)
+	VisibilityPath(element.__owner, 'ForceUpdate', element.__owner.unit)
 end
 
 local function Enable(self)
@@ -174,17 +184,11 @@ local function Enable(self)
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 		end
 
-		if(not element.UpdateColor) then
-			element.UpdateColor = UpdateColor
-		end
-
 		MonkStaggerBar:UnregisterEvent('PLAYER_ENTERING_WORLD')
 		MonkStaggerBar:UnregisterEvent('PLAYER_SPECIALIZATION_CHANGED')
 		MonkStaggerBar:UnregisterEvent('UNIT_DISPLAYPOWER')
 		MonkStaggerBar:UnregisterEvent('UNIT_EXITED_VEHICLE')
 		MonkStaggerBar:UnregisterEvent('UPDATE_VEHICLE_ACTIONBAR')
-
-		element:Hide()
 
 		return true
 	end

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -79,11 +79,10 @@ local function UpdateColor(self, event, unit)
 		end
 	end
 
-	--[[ Callback: Stagger:PostUpdateColor(unit, r, g, b)
+	--[[ Callback: Stagger:PostUpdateColor(r, g, b)
 	Called after the element color has been updated.
 
 	* self - the Stagger element
-	* unit - the unit for which the update has been triggered (string)
 	* r    - the red component of the used color (number)[0-1]
 	* g    - the green component of the used color (number)[0-1]
 	* b    - the blue component of the used color (number)[0-1]

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -173,7 +173,7 @@ end
 
 local function Enable(self)
 	local element = self.Stagger
-	if(element) then
+	if(element and UnitIsUnit(unit, 'player')) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
 

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -180,7 +180,7 @@ local function ForceUpdate(element)
 	VisibilityPath(element.__owner, 'ForceUpdate', element.__owner.unit)
 end
 
-local function Enable(self)
+local function Enable(self, unit)
 	local element = self.Stagger
 	if(element and UnitIsUnit(unit, 'player')) then
 		element.__owner = self

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -180,7 +180,7 @@ local function Enable(self)
 		self:RegisterEvent('UNIT_DISPLAYPOWER', VisibilityPath)
 		self:RegisterEvent('PLAYER_TALENT_UPDATE', VisibilityPath, true)
 
-		if(element:IsObjectType('StatusBar') and not element:GetStatusBarTexture()) then
+		if(element:IsObjectType('StatusBar') and not (element:GetStatusBarTexture() or element:GetStatusBarAtlas())) then
 			element:SetStatusBarTexture([[Interface\TargetingFrame\UI-StatusBar]])
 		end
 

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -79,6 +79,15 @@ local function UpdateColor(self, event, unit)
 		end
 	end
 
+	--[[ Callback: Stagger:PostUpdateColor(unit, r, g, b)
+	Called after the element color has been updated.
+
+	* self - the Stagger element
+	* unit - the unit for which the update has been triggered (string)
+	* r    - the red component of the used color (number)[0-1]
+	* g    - the green component of the used color (number)[0-1]
+	* b    - the blue component of the used color (number)[0-1]
+	--]]
 	if(element.PostUpdateColor) then
 		element:PostUpdateColor(r, g, b)
 	end

--- a/elements/threatindicator.lua
+++ b/elements/threatindicator.lua
@@ -61,7 +61,7 @@ local function Update(self, event, unit)
 
 	local r, g, b
 	if(status and status > 0) then
-		r, g, b = GetThreatStatusColor(status)
+		r, g, b = unpack(self.colors.threat[status])
 
 		if(element.SetVertexColor) then
 			element:SetVertexColor(r, g, b)


### PR DESCRIPTION
The main goal of this PR is to separate colour updates from value updates where possible. So instead of being bundled up as one big `Update` function that handles both maths/behaviour and colouring, there will be two functions:
- `Update` for maths and behaviour
- `UpdateColor` for colouring

This way users will be able to override these individually. Why would we want that? Because, at least from my experience, layout devs tend to override our `Update` functions to alter or completely disable the colouring.

In addition to that, new colours and colour-related options will be added to oUF and its elements. For instance, threat and alternative power colours weren't present in the `oUF.colors` table.