### PR TITLE
Updated Private methods to use camelCase

### DIFF
--- a/elements/health.lua
+++ b/elements/health.lua
@@ -33,7 +33,7 @@ The following options are listed by priority. The first check that returns true 
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
 .colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
-                     `selection` is defined by the return value of Private.UnitSelectionType, a wrapper function
+                     `selection` is defined by the return value of Private.unitSelectionType, a wrapper function
                      for [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
@@ -85,7 +85,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local UnitSelectionType = Private.UnitSelectionType
+local unitSelectionType = Private.unitSelectionType
 
 local function UpdateColor(element, unit, cur, max)
 	local parent = element.__owner
@@ -100,8 +100,8 @@ local function UpdateColor(element, unit, cur, max)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
-	elseif(element.colorSelection and UnitSelectionType(unit, element.considerSelectionInCombatHostile)) then
-		t = parent.colors.selection[UnitSelectionType(unit, element.considerSelectionInCombatHostile)]
+	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then
+		t = parent.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -46,7 +46,7 @@ The following options are listed by priority. The first check that returns true 
 .colorClassPet     - Use `self.colors.class[class]` to color the bar if the unit is player controlled, but not a player
                      (boolean)
 .colorSelection    - Use `self.colors.selection[selection]` to color the bar based on the unit's selection color.
-                     `selection` is defined by the return value of Private.UnitSelectionType, a wrapper function
+                     `selection` is defined by the return value of Private.unitSelectionType, a wrapper function
                      for [UnitSelectionType](https://wow.gamepedia.com/API_UnitSelectionType) (boolean)
 .colorReaction     - Use `self.colors.reaction[reaction]` to color the bar based on the player's reaction towards the
                      unit. `reaction` is defined by the return value of
@@ -98,7 +98,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local UnitSelectionType = Private.UnitSelectionType
+local unitSelectionType = Private.unitSelectionType
 
 -- sourced from FrameXML/UnitPowerBarAlt.lua
 local ALTERNATE_POWER_INDEX = Enum.PowerType.Alternate or 10
@@ -142,8 +142,8 @@ local function UpdateColor(element, unit, cur, min, max, displayType)
 		(element.colorClassPet and UnitPlayerControlled(unit) and not UnitIsPlayer(unit)) then
 		local _, class = UnitClass(unit)
 		t = parent.colors.class[class]
-	elseif(element.colorSelection and UnitSelectionType(unit, element.considerSelectionInCombatHostile)) then
-		t = parent.colors.selection[UnitSelectionType(unit, element.considerSelectionInCombatHostile)]
+	elseif(element.colorSelection and unitSelectionType(unit, element.considerSelectionInCombatHostile)) then
+		t = parent.colors.selection[unitSelectionType(unit, element.considerSelectionInCombatHostile)]
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		t = parent.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth) then

--- a/elements/readycheckindicator.lua
+++ b/elements/readycheckindicator.lua
@@ -40,7 +40,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local UnitExists = Private.UnitExists
+local unitExists = Private.unitExists
 
 local function OnFinished(self)
 	local element = self:GetParent()
@@ -70,7 +70,7 @@ local function Update(self, event)
 	end
 
 	local status = GetReadyCheckStatus(unit)
-	if(UnitExists(unit) and status) then
+	if(unitExists(unit) and status) then
 		if(status == 'ready') then
 			element:SetTexture(element.readyTexture)
 		elseif(status == 'notready') then

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -69,7 +69,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local UnitExists = Private.UnitExists
+local unitExists = Private.unitExists
 
 local _PATTERN = '%[..-%]+'
 
@@ -558,7 +558,7 @@ local function createOnUpdate(timer)
 		frame:SetScript('OnUpdate', function(self, elapsed)
 			if(total >= timer) then
 				for _, fs in next, strings do
-					if(fs.parent:IsShown() and UnitExists(fs.parent.unit)) then
+					if(fs.parent:IsShown() and unitExists(fs.parent.unit)) then
 						fs:UpdateTag()
 					end
 				end

--- a/elements/threatindicator.lua
+++ b/elements/threatindicator.lua
@@ -32,7 +32,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local UnitExists = Private.UnitExists
+local unitExists = Private.unitExists
 
 local function Update(self, event, unit)
 	if(unit ~= self.unit) then return end
@@ -51,8 +51,8 @@ local function Update(self, event, unit)
 
 	local status
 	-- BUG: Non-existent '*target' or '*pet' units cause UnitThreatSituation() errors
-	if(UnitExists(unit)) then
-		if(feedbackUnit and feedbackUnit ~= unit and UnitExists(feedbackUnit)) then
+	if(unitExists(unit)) then
+		if(feedbackUnit and feedbackUnit ~= unit and unitExists(feedbackUnit)) then
 			status = UnitThreatSituation(feedbackUnit, unit)
 		else
 			status = UnitThreatSituation(unit)

--- a/ouf.lua
+++ b/ouf.lua
@@ -11,7 +11,7 @@ local Private = oUF.Private
 local argcheck = Private.argcheck
 local error = Private.error
 local print = Private.print
-local UnitExists = Private.UnitExists
+local unitExists = Private.unitExists
 
 local styles, style = {}
 local callback, objects, headers = {}, {}, {}
@@ -58,7 +58,7 @@ local function updateActiveUnit(self, event, unit)
 		modUnit = 'vehicle'
 	end
 
-	if(not UnitExists(modUnit)) then return end
+	if(not unitExists(modUnit)) then return end
 
 	-- Change the active unit and run a full update.
 	if(Private.UpdateUnits(self, modUnit, realUnit)) then
@@ -193,7 +193,7 @@ for k, v in next, {
 	--]]
 	UpdateAllElements = function(self, event)
 		local unit = self.unit
-		if(not UnitExists(unit)) then return end
+		if(not unitExists(unit)) then return end
 
 		assert(type(event) == 'string', "Invalid argument 'event' in UpdateAllElements.")
 

--- a/private.lua
+++ b/private.lua
@@ -21,7 +21,7 @@ function Private.error(...)
 	Private.print('|cffff0000Error:|r ' .. string.format(...))
 end
 
-function Private.UnitExists(unit)
+function Private.unitExists(unit)
 	return unit and (UnitExists(unit) or ShowBossFrameWhenUninteractable(unit))
 end
 

--- a/private.lua
+++ b/private.lua
@@ -54,7 +54,7 @@ local selectionTypes = {
 	[13] = 13,
 }
 
-function Private.UnitSelectionType(unit, considerHostile)
+function Private.unitSelectionType(unit, considerHostile)
 	if(considerHostile and UnitThreatSituation('player', unit)) then
 		return 0
 	else


### PR DESCRIPTION
It's a cosmetic PR for the most part, however, it's needed to make the difference between Blizz's methods and our wrappers more obvious. While wrappers might share their names w/ og methods, inputs might be completely different.