### PR TITLE
tags: Update the system

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -463,6 +463,8 @@ local tags = setmetatable(
 				end
 			end
 
+			assert(type(val) == 'function', 'Tag function must be a function or a string that evaluates to a function.')
+
 			-- We don't want to clash with any custom envs
 			if(getfenv(val) == _G) then
 				-- pcall is needed for cases when Blizz functions are passed as

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -478,6 +478,21 @@ local tags = setmetatable(
 
 _ENV._TAGS = tags
 
+local vars = setmetatable({}, {
+	__newindex = function(self, key, val)
+		if(type(val) == 'string') then
+			local func = loadstring('return ' .. val)
+			if(func) then
+				val = func() or val
+			end
+		end
+
+		rawset(self, key, val)
+	end,
+})
+
+_ENV._VARS = vars
+
 local tagEvents = {
 	['affix']               = 'UNIT_CLASSIFICATION_CHANGED',
 	['arcanecharges']       = 'UNIT_POWER_UPDATE PLAYER_TALENT_UPDATE',
@@ -842,6 +857,7 @@ oUF.Tags = {
 	Methods = tags,
 	Events = tagEvents,
 	SharedEvents = unitlessEvents,
+	Vars = vars,
 }
 
 oUF:RegisterMetaFunction('Tag', Tag)

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -548,9 +548,7 @@ local onUpdates = {}
 local eventlessUnits = {}
 
 local function createOnUpdate(timer)
-	local OnUpdate = onUpdates[timer]
-
-	if(not OnUpdate) then
+	if(not onUpdates[timer]) then
 		local total = timer
 		local frame = CreateFrame('Frame')
 		local strings = eventlessUnits[timer]
@@ -580,11 +578,15 @@ Used to update all tags on a frame.
 --]]
 local function Update(self)
 	if(self.__tags) then
-		for _, fs in next, self.__tags do
+		for fs in next, self.__tags do
 			fs:UpdateTag()
 		end
 	end
 end
+
+local tagPool = {}
+local funcPool = {}
+local tmp = {}
 
 local function getTagName(tag)
 	local tagStart = (tag:match('>+()') or 2)
@@ -594,71 +596,7 @@ local function getTagName(tag)
 	return tag:sub(tagStart, tagEnd), tagStart, tagEnd
 end
 
-local function registerEvent(fontstr, event)
-	if(not events[event]) then events[event] = {} end
-
-	frame:RegisterEvent(event)
-	table.insert(events[event], fontstr)
-end
-
-local function registerEvents(fontstr, tagstr)
-	for tag in tagstr:gmatch(_PATTERN) do
-		tag = getTagName(tag)
-		local tagevents = tagEvents[tag]
-		if(tagevents) then
-			for event in tagevents:gmatch('%S+') do
-				registerEvent(fontstr, event)
-			end
-		end
-	end
-end
-
-local function unregisterEvents(fontstr)
-	for event, data in next, events do
-		for i, tagfsstr in next, data do
-			if(tagfsstr == fontstr) then
-				if(#data == 1) then
-					frame:UnregisterEvent(event)
-				end
-
-				table.remove(data, i)
-			end
-		end
-	end
-end
-
-local tagPool = {}
-local funcPool = {}
-local tmp = {}
-
---[[ Tags: frame:Tag(fs, tagstr, ...)
-Used to register a tag on a unit frame.
-
-* self   - the unit frame on which to register the tag
-* fs     - the font string to display the tag (FontString)
-* tagstr - the tag string (string)
-* ...    - additional optional unitID(s) the tag should update for
---]]
-local function Tag(self, fs, tagstr, ...)
-	if(not fs or not tagstr) then return end
-
-	if(not self.__tags) then
-		self.__tags = {}
-		table.insert(self.__elements, Update)
-	else
-		-- Since people ignore everything that's good practice - unregister the tag
-		-- if it already exists.
-		for _, tag in pairs(self.__tags) do
-			if(fs == tag) then
-				-- We don't need to remove it from the __tags table as Untag handles
-				-- that for us.
-				self:Untag(fs)
-			end
-		end
-	end
-
-	fs.parent = self
-
+local function getTagFunc(tagstr)
 	local func = tagPool[tagstr]
 	if(not func) then
 		local format, numTags = tagstr:gsub('%%', '%%%%'):gsub(_PATTERN, '%%s')
@@ -787,7 +725,65 @@ local function Tag(self, fs, tagstr, ...)
 
 		tagPool[tagstr] = func
 	end
-	fs.UpdateTag = func
+
+	return func
+end
+
+local function registerEvent(fontstr, event)
+	if(not events[event]) then events[event] = {} end
+
+	frame:RegisterEvent(event)
+	table.insert(events[event], fontstr)
+end
+
+local function registerEvents(fontstr, tagstr)
+	for tag in tagstr:gmatch(_PATTERN) do
+		tag = getTagName(tag)
+		local tagevents = tagEvents[tag]
+		if(tagevents) then
+			for event in tagevents:gmatch('%S+') do
+				registerEvent(fontstr, event)
+			end
+		end
+	end
+end
+
+local function unregisterEvents(fontstr)
+	for event, data in next, events do
+		for i, tagfsstr in next, data do
+			if(tagfsstr == fontstr) then
+				if(#data == 1) then
+					frame:UnregisterEvent(event)
+				end
+
+				table.remove(data, i)
+			end
+		end
+	end
+end
+
+--[[ Tags: frame:Tag(fs, tagstr, ...)
+Used to register a tag on a unit frame.
+
+* self   - the unit frame on which to register the tag
+* fs     - the font string to display the tag (FontString)
+* tagstr - the tag string (string)
+* ...    - additional optional unitID(s) the tag should update for
+--]]
+local function Tag(self, fs, tagstr, ...)
+	if(not fs or not tagstr) then return end
+
+	if(not self.__tags) then
+		self.__tags = {}
+		table.insert(self.__elements, Update)
+	elseif(self.__tags[fs]) then
+		-- We don't need to remove it from the __tags table as Untag handles
+		-- that for us.
+		self:Untag(fs)
+	end
+
+	fs.parent = self
+	fs.UpdateTag = getTagFunc(tagstr)
 
 	local unit = self.unit
 	if(self.__eventless or fs.frequentUpdates) then
@@ -811,13 +807,12 @@ local function Tag(self, fs, tagstr, ...)
 			end
 
 			for index = 1, select('#', ...) do
-				local unit = select(index, ...)
-				fs.extraUnits[unit] = true
+				fs.extraUnits[select(index, ...)] = true
 			end
 		end
 	end
 
-	table.insert(self.__tags, fs)
+	self.__tags[fs] = true
 end
 
 --[[ Tags: frame:Untag(fs)
@@ -838,13 +833,9 @@ local function Untag(self, fs)
 		end
 	end
 
-	for i, fontstr in next, self.__tags do
-		if(fontstr == fs) then
-			table.remove(self.__tags, i)
-		end
-	end
-
 	fs.UpdateTag = nil
+
+	self.__tags[fs] = nil
 end
 
 oUF.Tags = {

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -883,6 +883,21 @@ oUF.Tags = {
 			end
 		end
 	end,
+	RefreshEvents = function(self, tag)
+		if(not tag) then return end
+
+		tag = '%[' .. tag .. '%]'
+		for tagstr in next, tagPool do
+			if(tagstr:match(tag)) then
+				for fs, ts in next, fsPool do
+					if(ts == tagstr) then
+						unregisterEvents(fs)
+						registerEvents(fs, tagstr)
+					end
+				end
+			end
+		end
+	end,
 }
 
 oUF:RegisterMetaFunction('Tag', Tag)


### PR DESCRIPTION
This PR primarily is targetted at layout devs who have in-game configs. Its goal is to improve the process of creating custom tags via GUIs.

Normally, when you write a new tag in Lua, you can just store additional constants, tables, or helper methods in the higher level of scope, and then directly access those from your tag code. However, you can't really do that when your tag is just a string that's loaded via `loadstring`. Previously, you'd have to either create additional tables or even funcs inside the tag string, and those would be created on every single tag func call, or create global vars, which isn't optimal at all.

So, let's say you want to create a tag named `"tag"` that returns `"yes!"` if your target's class is either mage or shaman, then your tag's code will look like this:

```lua
local canPurge = {
	MAGE = true,
	SHAMAN = true,
}

oUF.Tags.Methods["tag"] = function()
	return canPurge[UnitClass('target')] and "yes!" or "no!"
end
```

However, you can't access the local `canPurge` table if your tag's code is a string:

```lua
oUF.Tags.Methods["tag"] = [[function()
	return canPurge[UnitClass("target")] and "yes!" or "no!"
end]]
```

That's where the new `oUF.Tags.Vars` comes in.

```Lua
oUF.Tags.Vars["tag"] = {
	canPurge = {
		MAGE = true,
		SHAMAN = true,
	},
}
```

Now you can access the `canPurge` table from at `_VARS["tag"].canPurge`:

```lua
oUF.Tags.Methods["tag"] = [[function()
	return _VARS["tag"].canPurge[UnitClass("target")] and "yes!" or "no!"
end]]
```

If you're good at naming vars and/or aren't afraid of name collisions, you can do something like this:

```Lua
oUF.Tags.Vars["canPurge"] = {
	MAGE = true,
	SHAMAN = true,
}

oUF.Tags.Methods["tag"] = [[function()
	return _VARS.canPurge[UnitClass("target")] and "yes!" or "no!"
end]]
```

`_VARS` is shared by all oUF tags, so it might be better to keep certain things in their own tables, but things that are used by multiple tags could be stored in `_VARS` as is.

`oUF.Tags.Vars` accepts all types of vars, however, strings are a special case. oUF will try to parse a string w/ `loadstring`, if possible, execute it, and store its result, but in case of failure, it'll just store that string as is.

-- edit 

Added two new methods to oUF.Tags: `:RefreshMethods(tag)` and `:RefreshEvents(tag)`.

`:RefreshMethods(tag)` regenerates/rebuilds tag functions for all tag strings that use provided tag, allows for tag functions' updates w/o reloading the UI.

`:RefreshEvents(tag)` unregisters and then registers events on font strings that use provided tag, this method will allow layout devs to reregister events after editing event lists w/o using `Untag` + `Tag` methods.