### PR TITLE
blizzard: Do not re-parent nameplates

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -14,7 +14,11 @@ local hiddenParent = CreateFrame('Frame', nil, UIParent)
 hiddenParent:SetAllPoints()
 hiddenParent:Hide()
 
-local function handleFrame(baseName)
+local function insecureOnShow(self)
+	self:Hide()
+end
+
+local function handleFrame(baseName, doNotReparent)
 	local frame
 	if(type(baseName) == 'string') then
 		frame = _G[baseName]
@@ -26,8 +30,9 @@ local function handleFrame(baseName)
 		frame:UnregisterAllEvents()
 		frame:Hide()
 
-		-- Keep frame hidden without causing taint
-		frame:SetParent(hiddenParent)
+		if(not doNotReparent) then
+			frame:SetParent(hiddenParent)
+		end
 
 		local health = frame.healthBar or frame.healthbar
 		if(health) then
@@ -116,7 +121,9 @@ function oUF:DisableBlizzard(unit)
 	elseif(unit:match('nameplate%d+$')) then
 		local frame = C_NamePlate.GetNamePlateForUnit(unit)
 		if(frame and frame.UnitFrame) then
-			handleFrame(frame.UnitFrame)
+			frame.UnitFrame:HookScript('OnShow', insecureOnShow)
+
+			handleFrame(frame.UnitFrame, true)
 		end
 	end
 end


### PR DESCRIPTION
Due to [UI changes in 8.2](https://us.forums.blizzard.com/en/wow/t/ui-changes-in-rise-of-azshara/202487), nameplates can only be parented to their base plates.

```
We added new restricted frames system that affects frame anchoring:

- Frames that are anchored to a restricted frame can only have their other anchors
  set to frames within that same anchor hierarchy

- New restricted frames include  
  - Nameplates
```

W/o it you'll encounter errors like this one:
```
Message: Interface\FrameXML\CompactUnitFrame.lua:1901: Action[SetPoint] failed because
[SetPoint would result in anchor family connection]: attempted from:
NamePlate1UnitFrame:SetAllPoints.
```