### PR TITLE
Fix: Auras on nameplates breaking tooltips

### DIFF
--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -78,7 +78,7 @@ end
 local function onEnter(self)
 	if(not self:IsVisible()) then return end
 
-	GameTooltip:SetOwner(self, 'ANCHOR_BOTTOMRIGHT')
+	GameTooltip:SetOwner(self, 'ANCHOR_CURSOR')
 	self:UpdateTooltip()
 end
 


### PR DESCRIPTION
I have been chasing this issue for awhile now. I am assuming the root casue of the issue has to do with the new protected frame changes.


Background on the issue: Item tooltips "randomly" break and no longer stay on the screen example:
![60424948-c1a8ce80-9bf1-11e9-951d-d19ec19d31cf](https://user-images.githubusercontent.com/704321/60856650-754f2700-a1cd-11e9-9a47-e2e8301bb387.jpg)

After much searching i found that if you have auras on your nameplates (example [code i am using](https://github.com/Wutname1/SpartanUI/blob/master/Components/Nameplates.lua#L166-L170)).  Once you mouse over the buff on a tooltip your item tooltips will break and not stay on the screen. It will never generate a LUA error.  I am assuming that since the parent tree is part of a nameplate with the existing code combined with the new protected status of nameplates this then causes a issue when the tooltip is moved off of the nameplate. 

Best solution i could think of is to simply attach the tooltip to the cursor instead of the buff icon.