### PR TITLE
auras: Add .tooltipAnchor option

### DIFF
--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -28,6 +28,8 @@ At least one of the above widgets must be present for the element to work.
 .initialAnchor      - Anchor point for the icons. Defaults to 'BOTTOMLEFT' (string)
 .filter             - Custom filter list for auras to display. Defaults to 'HELPFUL' for buffs and 'HARMFUL' for
                       debuffs (string)
+.tooltipAnchor      - Anchor point for the tooltip. Defaults to 'ANCHOR_BOTTOMRIGHT', however, if a frame has anchoring
+                      restrictions it will be set to 'ANCHOR_CURSOR' (string)
 
 ## Options Auras
 
@@ -78,7 +80,7 @@ end
 local function onEnter(self)
 	if(not self:IsVisible()) then return end
 
-	GameTooltip:SetOwner(self, 'ANCHOR_BOTTOMRIGHT')
+	GameTooltip:SetOwner(self, self:GetParent().__owner.tooltipAnchor)
 	self:UpdateTooltip()
 end
 
@@ -488,6 +490,12 @@ local function Enable(self)
 			buffs.createdIcons = buffs.createdIcons or 0
 			buffs.anchoredIcons = 0
 
+			if(not pcall(self.GetCenter, self)) then
+				buffs.tooltipAnchor = 'ANCHOR_CURSOR'
+			else
+				buffs.tooltipAnchor = buffs.tooltipAnchor or 'ANCHOR_BOTTOMRIGHT'
+			end
+
 			buffs:Show()
 		end
 
@@ -499,6 +507,12 @@ local function Enable(self)
 			debuffs.createdIcons = debuffs.createdIcons or 0
 			debuffs.anchoredIcons = 0
 
+			if(not pcall(self.GetCenter, self)) then
+				debuffs.tooltipAnchor = 'ANCHOR_CURSOR'
+			else
+				debuffs.tooltipAnchor = debuffs.tooltipAnchor or 'ANCHOR_BOTTOMRIGHT'
+			end
+
 			debuffs:Show()
 		end
 
@@ -509,6 +523,12 @@ local function Enable(self)
 
 			auras.createdIcons = auras.createdIcons or 0
 			auras.anchoredIcons = 0
+
+			if(not pcall(self.GetCenter, self)) then
+				auras.tooltipAnchor = 'ANCHOR_CURSOR'
+			else
+				auras.tooltipAnchor = auras.tooltipAnchor or 'ANCHOR_BOTTOMRIGHT'
+			end
 
 			auras:Show()
 		end


### PR DESCRIPTION
Due to [8.2 UI changes](https://us.forums.blizzard.com/en/wow/t/ui-changes-in-rise-of-azshara/202487), we should avoid parenting GameTooltip to frames with anchoring restrictions, otherwise, GameTooltip will inherit said restrictions.

This PR addresses #510, but it also adds an option to adjust GameTooltip's anchor point w/o the need to using the `CreateIcon` override.