### PR TITLE
Show/hide the Runes element itself during Enable/Disable

### DIFF
--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -192,6 +192,8 @@ local function Enable(self, unit)
 			end
 		end
 
+		element:Show()
+
 		self:RegisterEvent('PLAYER_SPECIALIZATION_CHANGED', Path)
 		self:RegisterEvent('RUNE_POWER_UPDATE', Path, true)
 
@@ -205,6 +207,8 @@ local function Disable(self)
 		for i = 1, #element do
 			element[i]:Hide()
 		end
+
+		element:Hide()
 
 		self:UnregisterEvent('PLAYER_SPECIALIZATION_CHANGED', Path)
 		self:UnregisterEvent('RUNE_POWER_UPDATE', Path)

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -192,7 +192,9 @@ local function Enable(self, unit)
 			end
 		end
 
-		element:Show()
+		if element.IsObjectType and element:IsObjectType("Frame") then
+			element:Show()
+		end
 
 		self:RegisterEvent('PLAYER_SPECIALIZATION_CHANGED', Path)
 		self:RegisterEvent('RUNE_POWER_UPDATE', Path, true)
@@ -208,7 +210,9 @@ local function Disable(self)
 			element[i]:Hide()
 		end
 
-		element:Hide()
+		if element.IsObjectType and element:IsObjectType("Frame") then
+			element:Hide()
+		end
 
 		self:UnregisterEvent('PLAYER_SPECIALIZATION_CHANGED', Path)
 		self:UnregisterEvent('RUNE_POWER_UPDATE', Path)

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -192,7 +192,7 @@ local function Enable(self, unit)
 			end
 		end
 
-		if element.IsObjectType and element:IsObjectType("Frame") then
+		if element.Show then
 			element:Show()
 		end
 
@@ -210,7 +210,7 @@ local function Disable(self)
 			element[i]:Hide()
 		end
 
-		if element.IsObjectType and element:IsObjectType("Frame") then
+		if element.Hide then
 			element:Hide()
 		end
 


### PR DESCRIPTION
This will help layouts that have things such as backdrops.

Noticed in ElvUI using NameOnly nameplates would cause the Runes backdrop to still appear because the object iself was not hidden, while the invididual runes were.