### PR TITLE
tags: Fix getTagName method

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -606,9 +606,8 @@ local funcPool = {}
 local tmp = {}
 
 local function getTagName(tag)
-	local tagStart = (tag:match('>+()') or 2)
-	local tagEnd = tag:match('.*()<+')
-	tagEnd = (tagEnd and tagEnd - 1) or -2
+	local tagStart = tag:match('>+()') or 2
+	local tagEnd = (tag:match('.-()<') or -1) - 1
 
 	return tag:sub(tagStart, tagEnd), tagStart, tagEnd
 end


### PR DESCRIPTION
In its current form it fails to get `tagEnd` correctly.

Current:
```
[tag] => tag 2 -2
[>tag] => tag 3 -2
[>>tag] => tag 4 -2
[tag<] => tag 2 4
[tag<<] => tag< 2 5
[>tag<] => tag 3 5
[>>tag<<] => tag< 4 7
```

New:
```
[tag] => tag 2 -2
[>tag] => tag 3 -2
[>>tag] => tag 4 -2
[tag<] => tag 2 4
[tag<<] => tag 2 4
[>tag<] => tag 3 5
[>>tag<<] => tag 4 6
```