### PR TITLE
castbar: Add fallback icon

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -130,7 +130,7 @@ local function UNIT_SPELLCAST_START(self, event, unit)
 	element:SetValue(0)
 
 	if(element.Text) then element.Text:SetText(text) end
-	if(element.Icon) then element.Icon:SetTexture(texture) end
+	if(element.Icon) then element.Icon:SetTexture(texture or "Interface\\Icons\\trade_engineering") end
 	if(element.Time) then element.Time:SetText() end
 
 	local shield = element.Shield
@@ -343,7 +343,7 @@ local function UNIT_SPELLCAST_CHANNEL_START(self, event, unit, _, spellID)
 	element:SetValue(duration)
 
 	if(element.Text) then element.Text:SetText(name) end
-	if(element.Icon) then element.Icon:SetTexture(texture) end
+	if(element.Icon) then element.Icon:SetTexture(texture or "Interface\\Icons\\trade_engineering") end
 	if(element.Time) then element.Time:SetText() end
 
 	local shield = element.Shield

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -91,6 +91,8 @@ local GetTime = GetTime
 local UnitCastingInfo = UnitCastingInfo
 local UnitChannelInfo = UnitChannelInfo
 
+local FALLBACK_ICON = 136243
+
 local function updateSafeZone(self)
 	local safeZone = self.SafeZone
 	local width = self:GetWidth()
@@ -130,7 +132,7 @@ local function UNIT_SPELLCAST_START(self, event, unit)
 	element:SetValue(0)
 
 	if(element.Text) then element.Text:SetText(text) end
-	if(element.Icon) then element.Icon:SetTexture(texture or "Interface\\Icons\\trade_engineering") end
+	if(element.Icon) then element.Icon:SetTexture(texture or FALLBACK_ICON) end
 	if(element.Time) then element.Time:SetText() end
 
 	local shield = element.Shield
@@ -343,7 +345,7 @@ local function UNIT_SPELLCAST_CHANNEL_START(self, event, unit, _, spellID)
 	element:SetValue(duration)
 
 	if(element.Text) then element.Text:SetText(name) end
-	if(element.Icon) then element.Icon:SetTexture(texture or "Interface\\Icons\\trade_engineering") end
+	if(element.Icon) then element.Icon:SetTexture(texture or FALLBACK_ICON) end
 	if(element.Time) then element.Time:SetText() end
 
 	local shield = element.Shield


### PR DESCRIPTION
In Legion and BfA some world interaction doen't have icon for casting spell.
You can test it with https://www.wowhead.com/spell=182547/grappling-gun in Stormheim.