### PR TITLE
core: add isRetail and isClassic boolean fields to the global object

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,6 @@
 local parent, ns = ...
 ns.oUF = {}
 ns.oUF.Private = {}
+
+ns.oUF.isClassic = select(4, GetBuildInfo()) < 20000
+ns.oUF.isRetail = not ns.oUF.isClassic


### PR DESCRIPTION
Need to make this available for layouts if they want to try to support all game versions from the same branch.