### PR TITLE
PhaseIndicator: Add Tooltip Support

### DIFF
--- a/elements/phaseindicator.lua
+++ b/elements/phaseindicator.lua
@@ -7,16 +7,27 @@ Toggles the visibility of an indicator based on the unit's phasing relative to t
 
 PhaseIndicator - Any UI widget.
 
+## Sub-Widgets
+
+Icon - A `Texture` to represent the phased status.
+
 ## Notes
 
 A default texture will be applied if the widget is a Texture and doesn't have a texture or a color set.
+OnEnter and OnLeave script handlers will be set to display a Tooltip if the widget is mouse enabled and does not have
+OnEnter and/or OnLeave handlers.
 
 ## Examples
 
     -- Position and size
-    local PhaseIndicator = self:CreateTexture(nil, 'OVERLAY')
+    local PhaseIndicator = CreateTexture('Frame', nil, self)
     PhaseIndicator:SetSize(16, 16)
     PhaseIndicator:SetPoint('TOPLEFT', self)
+    PhaseIndicator:EnableMouse(true)
+
+    local Icon = PhaseIndicator:CreateTexture(nil, 'OVERLAY')
+    Icon:SetAllPoints()
+    PhaseIndicator.Icon = Icon
 
     -- Register it with oUF
     self.PhaseIndicator = PhaseIndicator
@@ -24,6 +35,31 @@ A default texture will be applied if the widget is a Texture and doesn't have a 
 
 local _, ns = ...
 local oUF = ns.oUF
+
+--[[ Override: PhaseIndicator:UpdateTooltip()
+Used to populate the tooltip when the widget is hovered.
+
+* self - the PhaseIndicator widget
+--]]
+local function UpdateTooltip(element)
+	local unit = element.__owner.unit
+	local reason = UnitPhaseReason(unit)
+	local text = reason and PartyUtil.GetPhasedReasonString(reason, unit) or ''
+
+	GameTooltip:SetText(text, nil, nil, nil, nil, true)
+	GameTooltip:Show()
+end
+
+local function onEnter(element)
+	if(not element:IsVisible()) then return end
+
+	GameTooltip:SetOwner(element, 'ANCHOR_BOTTOMRIGHT')
+	element:UpdateTooltip()
+end
+
+local function onLeave()
+	GameTooltip:Hide()
+end
 
 local function Update(self, event, unit)
 	if(self.unit ~= unit) then return end
@@ -39,7 +75,7 @@ local function Update(self, event, unit)
 		element:PreUpdate()
 	end
 
-	local isInSamePhase = UnitInPhase(unit) and not UnitIsWarModePhased(unit)
+	local isInSamePhase = not UnitPhaseReason(unit)
 	if(not isInSamePhase and UnitIsPlayer(unit) and UnitIsConnected(unit)) then
 		element:Show()
 	else
@@ -80,8 +116,21 @@ local function Enable(self)
 
 		self:RegisterEvent('UNIT_PHASE', Path)
 
-		if(element:IsObjectType('Texture') and not element:GetTexture()) then
-			element:SetTexture([[Interface\TargetingFrame\UI-PhasingIcon]])
+		local icon = (element.Icon or element)
+		if(icon:IsObjectType('Texture') and not icon:GetTexture()) then
+			icon:SetTexture([[Interface\TargetingFrame\UI-PhasingIcon]])
+		end
+
+		if(element.IsMouseEnabled and element:IsMouseEnabled()) then
+			if(not element:GetScript('OnEnter')) then
+				element:SetScript('OnEnter', onEnter)
+			end
+
+			if(not element:GetScript('OnLeave')) then
+				element:SetScript('OnLeave', onLeave)
+			end
+
+			element.UpdateTooltip = element.UpdateTooltip or UpdateTooltip
 		end
 
 		return true

--- a/elements/phaseindicator.lua
+++ b/elements/phaseindicator.lua
@@ -20,7 +20,7 @@ OnEnter and/or OnLeave handlers.
 ## Examples
 
     -- Position and size
-    local PhaseIndicator = CreateTexture('Frame', nil, self)
+    local PhaseIndicator = CreateFrame('Frame', nil, self)
     PhaseIndicator:SetSize(16, 16)
     PhaseIndicator:SetPoint('TOPLEFT', self)
     PhaseIndicator:EnableMouse(true)


### PR DESCRIPTION
This adds tooltip support for the phase indicator for Shadowlands. It is backwards compatible.