### PR TITLE
tags: Update tag syntax

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -624,7 +624,7 @@ local function getBracketData(tag)
 		suffixOffset = 3
 	end
 
-	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)') or "", tag:match('{(%d+)}')
+	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)') or '', tag:match('{(%d+)}')
 end
 
 local function getTagFunc(tagstr)
@@ -645,7 +645,7 @@ local function getTagFunc(tagstr)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
-							if(str and str ~= "") then
+							if(str and str ~= '') then
 								return prefix .. (outputLength and str:sub(1, outputLength) or str) .. suffix
 							end
 						end
@@ -654,7 +654,7 @@ local function getTagFunc(tagstr)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
-							if(str and str ~= "") then
+							if(str and str ~= '') then
 								return prefix .. (outputLength and str:sub(1, outputLength) or str)
 							end
 						end
@@ -663,14 +663,14 @@ local function getTagFunc(tagstr)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
-							if(str and str ~= "") then
+							if(str and str ~= '') then
 								return (outputLength and str:sub(1, outputLength) or str) .. suffix
 							end
 						end
 					else
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
-							if(str and str ~= "") then
+							if(str and str ~= '') then
 								return (outputLength and str:sub(1, outputLength) or str)
 							end
 						end
@@ -877,7 +877,7 @@ end
 
 local function strip(tag)
 	-- remove prefix, output length, custom args, and suffix
-	return tag:gsub("%[.-%$>", "["):gsub("{.-}%]", "]"):gsub("%(.-%)%]", "]"):gsub("$<.-%]", "]")
+	return tag:gsub('%[.-%$>', '['):gsub('{.-}%]', ']'):gsub('%(.-%)%]', ']'):gsub('$<.-%]', ']')
 end
 
 oUF.Tags = {

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -624,7 +624,7 @@ local function getBracketData(tag)
 		suffixOffset = 3
 	end
 
-	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)') or ''
+	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)')
 end
 
 local function getTagFunc(tagstr)
@@ -644,7 +644,13 @@ local function getTagFunc(tagstr)
 						local suffix = bracket:sub(suffixStart, suffixEnd)
 
 						tagFunc = function(unit, realUnit)
-							local str = tag(unit, realUnit, string.split(',', customArgs))
+							local str
+							if(customArgs) then
+								str = tag(unit, realUnit, strsplit(',', customArgs))
+							else
+								str = tag(unit, realUnit)
+							end
+
 							if(str and str ~= '') then
 								return prefix .. str .. suffix
 							end
@@ -653,7 +659,13 @@ local function getTagFunc(tagstr)
 						local prefix = bracket:sub(2, prefixEnd)
 
 						tagFunc = function(unit, realUnit)
-							local str = tag(unit, realUnit, string.split(',', customArgs))
+							local str
+							if(customArgs) then
+								str = tag(unit, realUnit, strsplit(',', customArgs))
+							else
+								str = tag(unit, realUnit)
+							end
+
 							if(str and str ~= '') then
 								return prefix .. str
 							end
@@ -662,14 +674,26 @@ local function getTagFunc(tagstr)
 						local suffix = bracket:sub(suffixStart, -2)
 
 						tagFunc = function(unit, realUnit)
-							local str = tag(unit, realUnit, string.split(',', customArgs))
+							local str
+							if(customArgs) then
+								str = tag(unit, realUnit, strsplit(',', customArgs))
+							else
+								str = tag(unit, realUnit)
+							end
+
 							if(str and str ~= '') then
 								return str .. suffix
 							end
 						end
 					else
 						tagFunc = function(unit, realUnit)
-							local str = tag(unit, realUnit, string.split(',', customArgs))
+							local str
+							if(customArgs) then
+								str = tag(unit, realUnit, strsplit(',', customArgs))
+							else
+								str = tag(unit, realUnit)
+							end
+
 							if(str and str ~= '') then
 								return str
 							end

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -624,7 +624,23 @@ local function getBracketData(tag)
 		suffixOffset = 3
 	end
 
-	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)') or '', tag:match('{(%d+)}')
+	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)') or '', tonumber(tag:match('{(%d+)}'))
+end
+
+local function utf8shorten(str, length)
+	if(strlenutf8(str) <= length) then
+		return str
+	end
+
+	local index, output = 1, ""
+	for char in str:gmatch('[%z\1-\127\194-\244][\128-\191]*') do
+		if(index <= length) then
+			output = output .. char
+			index = index + 1
+		else
+			return output
+		end
+	end
 end
 
 local function getTagFunc(tagstr)
@@ -646,7 +662,7 @@ local function getTagFunc(tagstr)
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
 							if(str and str ~= '') then
-								return prefix .. (outputLength and str:sub(1, outputLength) or str) .. suffix
+								return prefix .. (outputLength and utf8shorten(str, outputLength) or str) .. suffix
 							end
 						end
 					elseif(2 - prefixEnd ~= 1) then
@@ -655,7 +671,7 @@ local function getTagFunc(tagstr)
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
 							if(str and str ~= '') then
-								return prefix .. (outputLength and str:sub(1, outputLength) or str)
+								return prefix .. (outputLength and utf8shorten(str, outputLength) or str)
 							end
 						end
 					elseif(suffixStart - suffixEnd ~= 1) then
@@ -664,14 +680,14 @@ local function getTagFunc(tagstr)
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
 							if(str and str ~= '') then
-								return (outputLength and str:sub(1, outputLength) or str) .. suffix
+								return (outputLength and utf8shorten(str, outputLength) or str) .. suffix
 							end
 						end
 					else
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit, string.split(',', customArgs))
 							if(str and str ~= '') then
-								return (outputLength and str:sub(1, outputLength) or str)
+								return (outputLength and utf8shorten(str, outputLength) or str)
 							end
 						end
 					end

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -644,7 +644,7 @@ local function getTagFunc(tagstr)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
-							if(str) then
+							if(str and str ~= "") then
 								return prefix .. str:sub(1, outputLength) .. suffix
 							end
 						end
@@ -653,7 +653,7 @@ local function getTagFunc(tagstr)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
-							if(str) then
+							if(str and str ~= "") then
 								return prefix .. str:sub(1, outputLength)
 							end
 						end
@@ -662,14 +662,14 @@ local function getTagFunc(tagstr)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
-							if(str) then
+							if(str and str ~= "") then
 								return str:sub(1, outputLength) .. suffix
 							end
 						end
 					else
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
-							if(str) then
+							if(str and str ~= "") then
 								return str:sub(1, outputLength)
 							end
 						end

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -638,7 +638,7 @@ local function getTagFunc(tagstr)
 				local tagName, prefixEnd, suffixStart, suffixEnd, outputLength = getBracketData(bracket)
 				local tag = tags[tagName]
 				if(tag) then
-					if(prefixEnd ~= 0 and suffixStart ~= 0) then
+					if(2 - prefixEnd ~= 1 and suffixStart - suffixEnd ~= 1) then
 						local prefix = bracket:sub(2, prefixEnd)
 						local suffix = bracket:sub(suffixStart, suffixEnd)
 
@@ -648,7 +648,7 @@ local function getTagFunc(tagstr)
 								return prefix .. str:sub(1, outputLength) .. suffix
 							end
 						end
-					elseif(prefixEnd ~= 0) then
+					elseif(2 - prefixEnd ~= 1) then
 						local prefix = bracket:sub(2, prefixEnd)
 
 						tagFunc = function(unit, realUnit)
@@ -657,13 +657,20 @@ local function getTagFunc(tagstr)
 								return prefix .. str:sub(1, outputLength)
 							end
 						end
-					elseif(suffixStart ~= 0) then
+					elseif(suffixStart - suffixEnd ~= 1) then
 						local suffix = bracket:sub(suffixStart, -2)
 
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
 							if(str) then
 								return str:sub(1, outputLength) .. suffix
+							end
+						end
+					else
+						tagFunc = function(unit, realUnit)
+							local str = tag(unit, realUnit)
+							if(str) then
+								return str:sub(1, outputLength)
 							end
 						end
 					end

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -687,74 +687,22 @@ local function getTagFunc(tagstr)
 			end
 		end
 
-		if(numTags == 1) then
-			func = function(self)
-				local parent = self.parent
-				local realUnit
-				if(self.overrideUnit) then
-					realUnit = parent.realUnit
-				end
-
-				_ENV._COLORS = parent.colors
-				_ENV._FRAME = parent
-				return self:SetFormattedText(
-					format,
-					args[1](parent.unit, realUnit) or ''
-				)
+		func = function(self)
+			local parent = self.parent
+			local unit = parent.unit
+			local realUnit
+			if(self.overrideUnit) then
+				realUnit = parent.realUnit
 			end
-		elseif(numTags == 2) then
-			func = function(self)
-				local parent = self.parent
-				local unit = parent.unit
-				local realUnit
-				if(self.overrideUnit) then
-					realUnit = parent.realUnit
-				end
 
-				_ENV._COLORS = parent.colors
-				_ENV._FRAME = parent
-				return self:SetFormattedText(
-					format,
-					args[1](unit, realUnit) or '',
-					args[2](unit, realUnit) or ''
-				)
+			_ENV._COLORS = parent.colors
+			_ENV._FRAME = parent
+			for i, f in next, args do
+				tmp[i] = f(unit, realUnit) or ''
 			end
-		elseif(numTags == 3) then
-			func = function(self)
-				local parent = self.parent
-				local unit = parent.unit
-				local realUnit
-				if(self.overrideUnit) then
-					realUnit = parent.realUnit
-				end
 
-				_ENV._COLORS = parent.colors
-				_ENV._FRAME = parent
-				return self:SetFormattedText(
-					format,
-					args[1](unit, realUnit) or '',
-					args[2](unit, realUnit) or '',
-					args[3](unit, realUnit) or ''
-				)
-			end
-		else
-			func = function(self)
-				local parent = self.parent
-				local unit = parent.unit
-				local realUnit
-				if(self.overrideUnit) then
-					realUnit = parent.realUnit
-				end
-
-				_ENV._COLORS = parent.colors
-				_ENV._FRAME = parent
-				for i, func in next, args do
-					tmp[i] = func(unit, realUnit) or ''
-				end
-
-				-- We do 1, numTags because tmp can hold several unneeded variables.
-				return self:SetFormattedText(format, unpack(tmp, 1, numTags))
-			end
+			-- We do 1, numTags because tmp can hold several unneeded variables.
+			return self:SetFormattedText(format, unpack(tmp, 1, numTags))
 		end
 
 		tagPool[tagstr] = func

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -645,7 +645,7 @@ local function getTagFunc(tagstr)
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
 							if(str and str ~= "") then
-								return prefix .. str:sub(1, outputLength) .. suffix
+								return prefix .. (outputLength and str:sub(1, outputLength) or str) .. suffix
 							end
 						end
 					elseif(2 - prefixEnd ~= 1) then
@@ -654,7 +654,7 @@ local function getTagFunc(tagstr)
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
 							if(str and str ~= "") then
-								return prefix .. str:sub(1, outputLength)
+								return prefix .. (outputLength and str:sub(1, outputLength) or str)
 							end
 						end
 					elseif(suffixStart - suffixEnd ~= 1) then
@@ -663,14 +663,14 @@ local function getTagFunc(tagstr)
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
 							if(str and str ~= "") then
-								return str:sub(1, outputLength) .. suffix
+								return (outputLength and str:sub(1, outputLength) or str) .. suffix
 							end
 						end
 					else
 						tagFunc = function(unit, realUnit)
 							local str = tag(unit, realUnit)
 							if(str and str ~= "") then
-								return str:sub(1, outputLength)
+								return (outputLength and str:sub(1, outputLength) or str)
 							end
 						end
 					end

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -639,7 +639,7 @@ local function getTagFunc(tagstr)
 				local tagName, prefixEnd, suffixStart, suffixEnd, customArgs = getBracketData(bracket)
 				local tag = tags[tagName]
 				if(tag) then
-					if(2 - prefixEnd ~= 1 and suffixStart - suffixEnd ~= 1) then
+					if(prefixEnd ~= 1 and suffixStart - suffixEnd ~= 1) then
 						local prefix = bracket:sub(2, prefixEnd)
 						local suffix = bracket:sub(suffixStart, suffixEnd)
 
@@ -649,7 +649,7 @@ local function getTagFunc(tagstr)
 								return prefix .. str .. suffix
 							end
 						end
-					elseif(2 - prefixEnd ~= 1) then
+					elseif(prefixEnd ~= 1) then
 						local prefix = bracket:sub(2, prefixEnd)
 
 						tagFunc = function(unit, realUnit)


### PR DESCRIPTION
This PR will update oUF tags syntax.

Currently, a complete oUF tag looks like this `[prefix>tag-name<suffix]`, however, using `>` and `<` as delimiters isn't really convenient due to them being fairly popular characters for tags. So this PR will change `>` to `$>` and `<` to `$<`.

This PR also adds a way for users to pass additional arguments to tag functions via `()`, for example `[tag-name(a,r,g,s)]`, a normal comma `,` is used as a delimiter, these will be passed to your tag function. So in case of `[tag-name(a,r,g,s)]`, `tag-name` function well receive 6 arguments: `unit`, `realUnit`, `'a'`, `'r'`, `'g'`, and `'s'`. 

With these changes a complete oUF tag will look like this `[prefix$>tag-name$<suffix(a,r,g,s)]`, only `tag-name` is required, `prefix$>`, `$<suffix`, and `(a,r,g,s)` are optional. For those who don't know `prefix` and `suffix` are optional parts of a tag that are only displayed when the tag function returns something other than `nil` or an empty `""` string.

Please note, that the order of optional features is very important.
- ✔ `[prefix$>tag-name(a,r,g,s)]` ✔
- ✔ `[tag-name$<suffix]` ✔
- ❌ `[(a,r,g,s)tag-name]` ❌
- ❌ `[tag-name$>suffix(a,r,g,s)$<suffix]` ❌