### PR TITLE
runes: fix for death knights without specialization in Shadowlands

### DIFF
--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -84,7 +84,7 @@ local function UpdateColor(element, runeID)
 	local spec = GetSpecialization() or 0
 
 	local color
-	if(spec ~= 0 and element.colorSpec) then
+	if(spec > 0 and spec < 4 and element.colorSpec) then
 		color = element.__owner.colors.runes[spec]
 	else
 		color = element.__owner.colors.power.RUNES


### PR DESCRIPTION
Death Knights start at level 8 without a spec and GetSpecialization() returns 5. Backwards compatible.