### PR TITLE
alternativepower: remove the realUnit check from the visibility condition

### DIFF
--- a/elements/alternativepower.lua
+++ b/elements/alternativepower.lua
@@ -201,8 +201,7 @@ local function Visibility(self, event, unit)
 	element.__barInfo = barInfo
 	if(barInfo and (barInfo.showOnRaid and (UnitInParty(unit) or UnitInRaid(unit))
 		or not barInfo.hideFromOthers
-		or UnitIsUnit(unit, 'player')
-		or UnitIsUnit(self.realUnit, 'player')))
+		or UnitIsUnit(unit, 'player')))
 	then
 		self:RegisterEvent('UNIT_POWER_UPDATE', Path)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)


### PR DESCRIPTION
ElvUI report:

> While doing the quest "Call of the Raven Mother" in Dreanor, I got these errors. I'm running the latest Dev version of ElvUI

```
Message: ...ns\ElvUI\Libraries\oUF\elements\alternativepower.lua:215: Usage: UnitIsUnit("unit", "otherUnit") Time: Sat Oct 17 15:06:29 2020 Count: 4 Stack: ...ns\ElvUI\Libraries\oUF\elements\alternativepower.lua:215: Usage: UnitIsUnit("unit", "otherUnit") [string "=[C]"]: in function UnitIsUnit'
```