### PR TITLE
Update power prediction

### DIFF
--- a/elements/powerprediction.lua
+++ b/elements/powerprediction.lua
@@ -132,9 +132,9 @@ local function ForceUpdate(element)
 	return Path(element.__owner, 'ForceUpdate', element.__owner.unit)
 end
 
-local function Enable(self)
+local function Enable(self, unit)
 	local element = self.PowerPrediction
-	if(element) then
+	if(element and UnitIsUnit(unit, 'player')) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
 

--- a/elements/powerprediction.lua
+++ b/elements/powerprediction.lua
@@ -66,29 +66,26 @@ local function Update(self, event, unit)
 
 	local _, _, _, startTime, endTime, _, _, _, spellID = UnitCastingInfo(unit)
 	local mainPowerType = UnitPowerType(unit)
-	local hasAltManaBar = ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass] and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass][mainPowerType]
+	local hasAltManaBar = ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass]
+		and ALT_MANA_BAR_PAIR_DISPLAY_INFO[playerClass][mainPowerType]
 	local mainCost, altCost = 0, 0
 
 	if(event == 'UNIT_SPELLCAST_START' and startTime ~= endTime) then
 		local costTable = GetSpellPowerCost(spellID)
+		-- hasRequiredAura is always false if there's only 1 subtable
+		local checkRequiredAura = #costTable > 1
+
 		for _, costInfo in next, costTable do
-			-- costInfo content:
-			-- - name: string (powerToken)
-			-- - type: number (powerType)
-			-- - cost: number
-			-- - costPercent: number
-			-- - costPerSec: number
-			-- - minCost: number
-			-- - hasRequiredAura: boolean
-			-- - requiredAuraID: number
-			if(costInfo.type == mainPowerType) then
-				mainCost = costInfo.cost
+			if(not checkRequiredAura or costInfo.hasRequiredAura) then
+				if(costInfo.type == mainPowerType) then
+					mainCost = costInfo.cost
 
-				break
-			elseif(costInfo.type == ADDITIONAL_POWER_BAR_INDEX) then
-				altCost = costInfo.cost
+					break
+				elseif(costInfo.type == ADDITIONAL_POWER_BAR_INDEX) then
+					altCost = costInfo.cost
 
-				break
+					break
+				end
 			end
 		end
 	end

--- a/elements/powerprediction.lua
+++ b/elements/powerprediction.lua
@@ -79,15 +79,25 @@ local function Update(self, event, unit)
 			if(not checkRequiredAura or costInfo.hasRequiredAura) then
 				if(costInfo.type == mainPowerType) then
 					mainCost = costInfo.cost
+					element.mainCost = mainCost
 
 					break
 				elseif(costInfo.type == ADDITIONAL_POWER_BAR_INDEX) then
 					altCost = costInfo.cost
+					element.altCost = altCost
 
 					break
 				end
 			end
 		end
+	elseif(spellID) then
+		-- if we try to cast a spell while casting another one we need to avoid
+		-- resetting the element
+		mainCost = element.mainCost or 0
+		altCost = element.altCost or 0
+	else
+		element.mainCost = mainCost
+		element.altCost = altCost
 	end
 
 	if(element.mainBar) then


### PR DESCRIPTION
First of all, this PR adds support for mutating spells like monk's Vivify (116670) whose spell power and cost change depending on the player's current spec. The `GetSpellPowerCost`'s output contains multiple tables, if a spell can change its properties in such a way:
```lua
Dump: value=GetSpellPowerCost(116670) 
[1]={ 
  [1]={ 
    hasRequiredAura=false, 
    type=0, 
    name="MANA", 
    cost=0, 
    minCost=0, 
    requiredAuraID=137024, 
    costPercent=4, 
    costPerSec=0 
  }, 
  [2]={ 
    hasRequiredAura=false, 
    type=3, 
    name="ENERGY", 
    cost=0, 
    minCost=0, 
    requiredAuraID=137023, 
    costPercent=0, 
    costPerSec=0 
  }, 
  [3]={ 
    hasRequiredAura=true, 
    type=3, 
    name="ENERGY", 
    cost=30, 
    minCost=30, 
    requiredAuraID=137025, 
    costPercent=0, 
    costPerSec=0 
  } 
}
```
So we should account for that.

Secondly, rn there's a bug where the elements resets itself, if a player spams ability buttons trying to queue up the next spell.

And lastly, from now on power prediction is a player-only element because `GetSpellPowerCost`, technically, returns info on the player's spells, while it can return info on unknown abilities by fetching it from DBCs or wherever, its output is highly influenced by the player's current class and/or spec. Also, cached info it's using for unknown abilities often seems to be incorrect.