### PR TITLE
phaseindicator: Check phase only for player units

### DIFF
--- a/elements/phaseindicator.lua
+++ b/elements/phaseindicator.lua
@@ -76,7 +76,9 @@ local function Update(self, event, unit)
 		element:PreUpdate()
 	end
 
-	local phaseReason = UnitIsConnected(unit) and UnitPhaseReason(unit) or nil
+	-- BUG: UnitPhaseReason returns wrong data for friendly NPCs in phased scenarios like WM or Chromie Time
+	-- https://github.com/Stanzilla/WoWUIBugs/issues/49
+	local phaseReason = UnitIsPlayer(unit) and UnitIsConnected(unit) and UnitPhaseReason(unit) or nil
 	if(phaseReason) then
 		element:Show()
 	else


### PR DESCRIPTION
Turns out `UnitPhaseReason` is buggy after all 😁🔫 