### PR TITLE
Event wrapper

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -106,6 +106,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
+local xpcall = Private.xpcall
 local unitExists = Private.unitExists
 
 local _PATTERN = '%[..-%]+'
@@ -775,8 +776,10 @@ end
 local function registerEvent(fontstr, event)
 	if(not events[event]) then events[event] = {} end
 
-	eventFrame:RegisterEvent(event)
-	table.insert(events[event], fontstr)
+	local isOK = xpcall(eventFrame.RegisterEvent, eventFrame, event)
+	if(isOK) then
+		table.insert(events[event], fontstr)
+	end
 end
 
 local function registerEvents(fontstr, tagstr)

--- a/private.lua
+++ b/private.lua
@@ -61,3 +61,11 @@ function Private.unitSelectionType(unit, considerHostile)
 		return selectionTypes[UnitSelectionType(unit, true)]
 	end
 end
+
+local function errorHandler(...)
+	return geterrorhandler()(...)
+end
+
+function Private.xpcall(func, ...)
+	return xpcall(func, errorHandler, ...)
+end


### PR DESCRIPTION
In early-mid BfA `RegisterEvent`, `RegisterUnitEvent`, and `UnregisterEvent` started throwing errors, it wasn't a problem until recently, in SL Blizz started renaming and removing events which in turn started breaking oUF which wouldn't happen prior to the aforementioned error change, it'd just fail silently and wouldn't affect the framework. Wrapping these functions, where it's needed, with `xpcall`s will give layout devs, plugin devs, and us extra time to gather, report, and/or react to this kind of issues without breaking oUF itself since it will load and continue to function properly despite all the event errors.

This **WILL NOT** stop error messages from popping up.