### PR TITLE
Event wrapper fix

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -3,8 +3,8 @@ local oUF = ns.oUF
 local Private = oUF.Private
 
 local argcheck = Private.argcheck
-local xpcall = Private.xpcall
 local error = Private.error
+local validateEvent = Private.validateEvent
 local validateUnit = Private.validateUnit
 local frame_metatable = Private.frame_metatable
 
@@ -105,8 +105,8 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 	argcheck(func, 3, 'function')
 
 	local curev = self[event]
-	local kind = type(curev)
 	if(curev) then
+		local kind = type(curev)
 		if(kind == 'function' and curev ~= func) then
 			self[event] = setmetatable({curev, func}, event_metatable)
 		elseif(kind == 'table') then
@@ -120,15 +120,24 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 		if(unitless or self.__eventless) then
 			-- re-register the event in case we have mixed registration
 			registerEvent(self, event)
+
 			if(self.unitEvents) then
 				self.unitEvents[event] = nil
 			end
 		end
-	else
-		local isOK
+	elseif(validateEvent(event)) then
+		self[event] = func
+
+		if(not self:GetScript('OnEvent')) then
+			self:SetScript('OnEvent', onEvent)
+		end
+
 		if(unitless or self.__eventless) then
-			isOK = xpcall(registerEvent, self, event)
+			registerEvent(self, event)
 		else
+			self.unitEvents = self.unitEvents or {}
+			self.unitEvents[event] = true
+
 			-- UpdateUnits will take care of unit event registration for header
 			-- units in case we don't have a valid unit yet
 			local unit1, unit2 = self.unit
@@ -137,19 +146,7 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 					unit2 = secondaryUnits[event][unit1]
 				end
 
-				isOK = xpcall(registerUnitEvent, self, event, unit1, unit2 or '')
-				if(isOK) then
-					self.unitEvents = self.unitEvents or {}
-					self.unitEvents[event] = true
-				end
-			end
-		end
-
-		if(isOK) then
-			self[event] = func
-
-			if(not self:GetScript('OnEvent')) then
-				self:SetScript('OnEvent', onEvent)
+				registerUnitEvent(self, event, unit1, unit2 or '')
 			end
 		end
 	end

--- a/private.lua
+++ b/private.lua
@@ -69,3 +69,12 @@ end
 function Private.xpcall(func, ...)
 	return xpcall(func, errorHandler, ...)
 end
+
+function Private.validateEvent(event)
+	local isOK = xpcall(validator.RegisterEvent, errorHandler, validator, event)
+	if(isOK) then
+		validator:UnregisterEvent(event)
+	end
+
+	return isOK
+end


### PR DESCRIPTION
As it's brought to my attention by @myzb, #563 kinda broke headers due to the fact that at the very beginning headers might not have legit units, so they don't pass the unit check, so the code doesn't even reach the event registration part. This PR addresses the issue by replacing all the wrappers with one `validateEvent` call. 