### PR TITLE
tags: Untag fontstrings correctly

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -796,14 +796,20 @@ end
 
 local function unregisterEvents(fontstr)
 	for event, data in next, events do
-		for i, tagfsstr in next, data do
+		local index = 1
+		local tagfsstr = data[index]
+		while tagfsstr do
 			if(tagfsstr == fontstr) then
 				if(#data == 1) then
 					eventFrame:UnregisterEvent(event)
 				end
 
-				table.remove(data, i)
+				table.remove(data, index)
+			else
+				index = index + 1
 			end
+
+			tagfsstr = data[index]
 		end
 	end
 end
@@ -874,10 +880,16 @@ local function Untag(self, fs)
 
 	unregisterEvents(fs)
 	for _, timers in next, eventlessUnits do
-		for i, fontstr in next, timers do
+		local index = 1
+		local fontstr = timers[index]
+		while fontstr do
 			if(fs == fontstr) then
 				table.remove(timers, i)
+			else
+				index = index + 1
 			end
+
+			fontstr = timers[index]
 		end
 	end
 


### PR DESCRIPTION
When calling `table.remove` on an indexed table the whole table is shifted to fill the gap, thus `next` will skip one fontstring and call it a day. This has the potential of leaving the fontstring in the events table and still being processed when updating tags, resulting in an error from the eventhandler trying to call `UpdateTag` on it.