### PR TITLE
tags: Render invalid text as plain text

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -685,9 +685,9 @@ local function getTagFunc(tagstr)
 				local tagName, prefixEnd, suffixStart, suffixEnd, customArgs = getBracketData(bracket)
 				local tag = tags[tagName]
 				if(tag) then
-					if(prefixEnd ~= 1 and suffixStart - suffixEnd ~= 1) then
-						local prefix = bracket:sub(2, prefixEnd)
-						local suffix = bracket:sub(suffixStart, suffixEnd)
+					if(prefixEnd ~= 1 or suffixStart - suffixEnd ~= 1) then
+						local prefix = prefixEnd ~= 1 and bracket:sub(2, prefixEnd) or ''
+						local suffix = suffixStart - suffixEnd ~= 1 and bracket:sub(suffixStart, suffixEnd) or ''
 
 						tagFunc = function(unit, realUnit)
 							local str
@@ -699,36 +699,6 @@ local function getTagFunc(tagstr)
 
 							if(str and str ~= '') then
 								return prefix .. str .. suffix
-							end
-						end
-					elseif(prefixEnd ~= 1) then
-						local prefix = bracket:sub(2, prefixEnd)
-
-						tagFunc = function(unit, realUnit)
-							local str
-							if(customArgs) then
-								str = tag(unit, realUnit, strsplit(',', customArgs))
-							else
-								str = tag(unit, realUnit)
-							end
-
-							if(str and str ~= '') then
-								return prefix .. str
-							end
-						end
-					elseif(suffixStart - suffixEnd ~= 1) then
-						local suffix = bracket:sub(suffixStart, suffixEnd)
-
-						tagFunc = function(unit, realUnit)
-							local str
-							if(customArgs) then
-								str = tag(unit, realUnit, strsplit(',', customArgs))
-							else
-								str = tag(unit, realUnit)
-							end
-
-							if(str and str ~= '') then
-								return str .. suffix
 							end
 						end
 					else

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -106,8 +106,9 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local xpcall = Private.xpcall
+local nierror = Private.nierror
 local unitExists = Private.unitExists
+local xpcall = Private.xpcall
 
 local _PATTERN = '%[..-%]+'
 
@@ -671,6 +672,12 @@ local function getTagFunc(tagstr)
 	if(not func) then
 		local format, numTags = tagstr:gsub('%%', '%%%%'):gsub(_PATTERN, '%%s')
 		local args = {}
+		local idx = 1
+
+		local format_ = {}
+		for i = 1, numTags do
+			format_[i] = '%s'
+		end
 
 		for bracket in tagstr:gmatch(_PATTERN) do
 			local tagFunc = funcPool[bracket] or tags[bracket:sub(2, -2)]
@@ -745,8 +752,16 @@ local function getTagFunc(tagstr)
 
 			if(tagFunc) then
 				table.insert(args, tagFunc)
+
+				idx = idx + 1
 			else
-				return error(string.format('Attempted to use invalid tag %s.', bracket), 3)
+				nierror(string.format('Attempted to use invalid tag %s.', bracket))
+
+				format_[idx] = bracket
+				format = string.format(format, unpack(format_, 1, numTags))
+				format_[idx] = '%s'
+
+				numTags = numTags - 1
 			end
 		end
 

--- a/private.lua
+++ b/private.lua
@@ -21,6 +21,10 @@ function Private.error(...)
 	Private.print('|cffff0000Error:|r ' .. string.format(...))
 end
 
+function Private.nierror(...)
+	return geterrorhandler()(...)
+end
+
 function Private.unitExists(unit)
 	return unit and (UnitExists(unit) or ShowBossFrameWhenUninteractable(unit))
 end
@@ -62,16 +66,12 @@ function Private.unitSelectionType(unit, considerHostile)
 	end
 end
 
-local function errorHandler(...)
-	return geterrorhandler()(...)
-end
-
 function Private.xpcall(func, ...)
-	return xpcall(func, errorHandler, ...)
+	return xpcall(func, Private.nierror, ...)
 end
 
 function Private.validateEvent(event)
-	local isOK = xpcall(validator.RegisterEvent, errorHandler, validator, event)
+	local isOK = xpcall(validator.RegisterEvent, Private.nierror, validator, event)
 	if(isOK) then
 		validator:UnregisterEvent(event)
 	end


### PR DESCRIPTION
Why?

Honestly, the way we handle invalid tags is kinda archaic. I don't know any modern apps that support tags, for instance, audio players like aimp or foobar, that completely break down if a user dares to use an invalid tag or make a typo. Invalid tags either are rendered as plain text or aren't rendered at all. I chose the former approach because this way it's more obvious what's actually broken.

Moreover, it's not 2004 anymore, nowadays many layouts have in-game configs that allow users to create custom tag strings, so if a dev removes a tag with an update, users who used said removed tag in their custom tag strings simply won't be able to load the ui until they either edit saved vars manually or wipe them entirely. Which isn't desirable to say the least.

oUF will continue to throw errors whenever invalid tags are encountered, for this reason I added internal `nierror` (non-interrupting error) method.