### PR TITLE
classpower: Add support for multiple charged power points

### DIFF
--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -110,7 +110,7 @@ local function Update(self, event, unit, powerType)
 		element:PreUpdate()
 	end
 
-	local cur, max, mod, oldMax, chargedIndex
+	local cur, max, mod, oldMax, chargedPoints
 	if(event ~= 'ClassPowerDisable') then
 		local powerID = unit == 'vehicle' and SPELL_POWER_COMBO_POINTS or ClassPowerID
 		cur = UnitPower(unit, powerID, true)
@@ -126,9 +126,7 @@ local function Update(self, event, unit, powerType)
 		end
 
 		if(PlayerClass == 'ROGUE') then
-			local chargedPoints = GetUnitChargedPowerPoints(unit)
-			-- according to Blizzard there will only be one
-			chargedIndex = chargedPoints and chargedPoints[1]
+			chargedPoints = GetUnitChargedPowerPoints(unit)
 
 			-- UNIT_POWER_POINT_CHARGE doesn't provide a power type
 			powerType = powerType or ClassPowerType
@@ -165,10 +163,10 @@ local function Update(self, event, unit, powerType)
 	* max           - the maximum amount of power (number)
 	* hasMaxChanged - indicates whether the maximum amount has changed since the last update (boolean)
 	* powerType     - the active power type (string)
-	* chargedIndex  - the index of the currently charged power point (number?)
+	* ...           - the indices of currently charged power points, if any
 	--]]
 	if(element.PostUpdate) then
-		return element:PostUpdate(cur, max, oldMax ~= max, powerType, chargedIndex)
+		return element:PostUpdate(cur, max, oldMax ~= max, powerType, chargedPoints and unpack(chargedPoints))
 	end
 end
 


### PR DESCRIPTION
Sadly, it's a breaking change. Alternatively, to avoid breaking existing layouts (and thus preserving incorrect behaviour) we could unpack `chargedPoints`.