### PR TITLE
Update packager version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           lua utils/changelog > CHANGELOG.md
 
       - name: Package and release
-        uses: BigWigsMods/packager@cd13fb1
+        uses: BigWigsMods/packager@v1.0.2
     env:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}
       WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}


### PR DESCRIPTION
We need to update the packager version to push the next version due to changes in hosting sites.
Also, workflows no longer support short sha, but the packager is now being tagged.