### PR TITLE
tags: Use UnitEffectiveLevel instead of UnitLevel

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -258,7 +258,7 @@ local tagStrings = {
 	end]],
 
 	['level'] = [[function(u)
-		local l = UnitLevel(u)
+		local l = UnitEffectiveLevel(u)
 		if(UnitIsWildBattlePet(u) or UnitIsBattlePetCompanion(u)) then
 			l = UnitBattlePetLevel(u)
 		end


### PR DESCRIPTION
It's most likely a leftover from per-TW times, but `UnitLevel` itself is no longer used for displaying info about units.