### PR TITLE
threatindicator: Fix docs

### DIFF
--- a/elements/threatindicator.lua
+++ b/elements/threatindicator.lua
@@ -15,7 +15,7 @@ A default texture will be applied if the widget is a Texture and doesn't have a 
 ## Options
 
 .feedbackUnit - The unit whose threat situation is being requested. If defined, it'll be passed as the first argument to
-                [GetThreatStatusColor](http://wowprogramming.com/docs/api/UnitThreatSituation.html).
+                [UnitThreatSituation](https://wow.gamepedia.com/API_UnitThreatSituation).
 
 ## Examples
 


### PR DESCRIPTION
I'm not exactly sure if I should use old `wow.gamepedia.com` or new `wowpedia.fandom.com` links here. I wonder if we should review docs everywhere 😒