### PR TITLE
core: Check if event is unitless

### DIFF
--- a/events.lua
+++ b/events.lua
@@ -5,6 +5,7 @@ local Private = oUF.Private
 local argcheck = Private.argcheck
 local validateEvent = Private.validateEvent
 local validateUnit = Private.validateUnit
+local isUnitEvent = Private.isUnitEvent
 local frame_metatable = Private.frame_metatable
 
 -- Original event methods
@@ -144,6 +145,10 @@ function frame_metatable.__index:RegisterEvent(event, func, unitless)
 				if(secondaryUnits[event]) then
 					unit2 = secondaryUnits[event][unit1]
 				end
+
+				-- be helpful and throw a custom error when attempting to register
+				-- an event that is unitless
+				assert(isUnitEvent(event, unit1), string.format('Event "%s" is not an unit event', event))
 
 				registerUnitEvent(self, event, unit1, unit2 or '')
 			end

--- a/private.lua
+++ b/private.lua
@@ -78,3 +78,12 @@ function Private.validateEvent(event)
 
 	return isOK
 end
+
+function Private.isUnitEvent(event, unit)
+	local isOK = pcall(validator.RegisterUnitEvent, validator, event, unit)
+	if(isOK) then
+		validator:UnregisterEvent(event)
+	end
+
+	return isOK
+end


### PR DESCRIPTION
Throw a custom error whenever something attempts to register a
unitless event without the unitless flag.