### PR TITLE
tags: look for args in the suffix only

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -645,10 +645,10 @@ local tagPool = {}
 local funcPool = {}
 local tmp = {}
 
-local function getBracketData(tag)
-	-- full tag syntax: '[prefix$>tag-name<$suffix(a,r,g,s)]'
-	local suffixEnd = (tag:match('()%(') or -1) - 1
 
+-- full tag syntax: '[prefix$>tag-name<$suffix(a,r,g,s)]'
+-- for a small test case see https://github.com/oUF-wow/oUF/pull/602
+local function getBracketData(tag)
 	local prefixEnd, prefixOffset = tag:match('()$>'), 1
 	if(not prefixEnd) then
 		prefixEnd = 1
@@ -657,6 +657,7 @@ local function getBracketData(tag)
 		prefixOffset = 3
 	end
 
+	local suffixEnd = (tag:match('()%(', prefixOffset + 1) or -1) - 1
 	local suffixStart, suffixOffset = tag:match('<$()', prefixEnd), 1
 	if(not suffixStart) then
 		suffixStart = suffixEnd + 1
@@ -664,7 +665,11 @@ local function getBracketData(tag)
 		suffixOffset = 3
 	end
 
-	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset), prefixEnd, suffixStart, suffixEnd, tag:match('%((.-)%)')
+	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset),
+		prefixEnd,
+		suffixStart,
+		suffixEnd,
+		tag:match('%((.-)%)', suffixOffset + 1)
 end
 
 local function getTagFunc(tagstr)


### PR DESCRIPTION
This fixes `'[ ($>test:tag<$)]'` resulting in ` (42` instead of ` (42)` in a backwards compatible way.

Here a simple use case for testing in case I missed something:

```lua
local function getBracketData(tag)
	-- full tag syntax: '[prefix$>tag-name<$suffix(a,r,g,s)]'
	local prefixEnd, prefixOffset = tag:match('()$>'), 1
	if(not prefixEnd) then
		prefixEnd = 1
	else
		prefixEnd = prefixEnd - 1
		prefixOffset = 3
	end

	local suffixEnd = (tag:match('()%(', prefixOffset + 1) or -1) - 1
	local suffixStart, suffixOffset = tag:match('<$()', prefixEnd), 1
	if(not suffixStart) then
		suffixStart = suffixEnd + 1
	else
		suffixOffset = 3
	end

	return tag:sub(prefixEnd + prefixOffset, suffixStart - suffixOffset),
		prefixEnd,
		suffixStart,
		suffixEnd,
		tag:match('%((.-)%)', suffixOffset + 1)
end

local function getAffixes(tag, prefixEnd, suffixStart, suffixEnd)
	local prefix = tag:sub(2, prefixEnd)
	local suffix = tag:sub(suffixStart, suffixEnd)

	return prefix ~= '' and prefix or nil,
		suffix ~= '' and suffix or nil
end

local tags = {
	'[test:tag]',
	'[prefix$>test:tag]',
	'[test:tag<$suffix]',
	'[prefix$>test:tag<$suffix]',
	'[test:tag(args)]',
	'[prefix$>test:tag(args)]',
	'[test:tag<$suffix(args)]',
	'[prefix$>test:tag<$suffix(args)]',
	'[ ($>test:tag<$)]',
	'[ ($>test:tag<$)(args)]',
}

for _, tag in next, tags do
	local name, pe, ss, se, args = getBracketData(tag)
	local p, s = getAffixes(tag, pe, ss, se)

	print(tag, name, p, s, args)
end
```

This breaks with something like `'[ ($>test:tag<$(suffix)(args)]'` which is IMO a limitation of the current tag syntax. We should have placed the argument list before the suffix delimiter. The following solution would fix this but in a backwards incompatible way:

```lua
local function getBracketData(tag)
	-- syntax: '[prefix$>tag-name(a,r,g,s)<$suffix]'
	local prefixEnd = tag:match('()$>') or 1
	local prefixOffset = prefixEnd == 1 and 1 or 2
	local suffixStart = tag:match('<$()') or -1
	local suffixOffset = suffixStart == -1 and -1 or -3
	local tagName = tag:sub(prefixEnd + prefixOffset, suffixStart + suffixOffset)
	local args = tagName:match('%((.-)%)')
	if (args) then
		tagName = tagName:gsub(args, ''):sub(1, -3)
	end

	if (prefixEnd ~= 1) then
		prefixEnd = prefixEnd - 1
	end

	return tagName, prefixEnd, suffixStart, -2, args
end
```