### PR TITLE
core: Rework how eventless units are handled

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -24,25 +24,6 @@ PetBattleFrameHider:SetAllPoints()
 PetBattleFrameHider:SetFrameStrata('LOW')
 RegisterStateDriver(PetBattleFrameHider, 'visibility', '[petbattle] hide; show')
 
--- updating of "invalid" units.
-local function enableTargetUpdate(object)
-	object.onUpdateFrequency = object.onUpdateFrequency or .5
-	object.__eventless = true
-
-	local total = 0
-	object:SetScript('OnUpdate', function(self, elapsed)
-		if(not self.unit) then
-			return
-		elseif(total > self.onUpdateFrequency) then
-			self:UpdateAllElements('OnUpdate')
-			total = 0
-		end
-
-		total = total + elapsed
-	end)
-end
-Private.enableTargetUpdate = enableTargetUpdate
-
 local function updateActiveUnit(self, event)
 	-- Calculate units to work with
 	local realUnit, modUnit = SecureButton_GetUnit(self), SecureButton_GetModifiedUnit(self)
@@ -262,12 +243,30 @@ local function updateRaid(self, event)
 	end
 end
 
+-- boss6-8 exsist in some encounters, but unit event registration seems to be
+-- completely broken for them, so instead we use OnUpdate to update them.
+local eventlessUnits = {
+	['boss6'] = true,
+	['boss7'] = true,
+	['boss8'] = true,
+}
+
+local function isEventlessUnit(unit)
+	return unit:match('%w+target') or eventlessUnits[unit]
+end
+
 local function initObject(unit, style, styleFunc, header, ...)
 	local num = select('#', ...)
 	for i = 1, num do
 		local object = select(i, ...)
 		local objectUnit = object:GetAttribute('oUF-guessUnit') or unit
 		local suffix = object:GetAttribute('unitsuffix')
+
+		-- Handle the case where someone has modified the unitsuffix attribute in
+		-- oUF-initialConfigFunction.
+		if(suffix and not objectUnit:match(suffix)) then
+			objectUnit = objectUnit .. suffix
+		end
 
 		object.__elements = {}
 		object.style = style
@@ -285,13 +284,7 @@ local function initObject(unit, style, styleFunc, header, ...)
 		-- frame will be stuck with the 'vehicle' unit.
 		object:RegisterEvent('PLAYER_ENTERING_WORLD', evalUnitAndUpdate, true)
 
-		-- Handle the case where someone has modified the unitsuffix attribute in
-		-- oUF-initialConfigFunction.
-		if(suffix and not objectUnit:match(suffix)) then
-			objectUnit = objectUnit .. suffix
-		end
-
-		if(not (suffix == 'target' or objectUnit and objectUnit:match('target'))) then
+		if(not isEventlessUnit(objectUnit)) then
 			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit)
 			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit)
 
@@ -308,15 +301,11 @@ local function initObject(unit, style, styleFunc, header, ...)
 			object:SetAttribute('*type1', 'target')
 			object:SetAttribute('*type2', 'togglemenu')
 
-			-- No need to enable this for *target frames.
-			if(not (unit:match('target') or suffix == 'target')) then
-				object:SetAttribute('toggleForVehicle', true)
-			end
-
-			-- Other boss and target units are handled by :HandleUnit().
-			if(suffix == 'target') then
-				enableTargetUpdate(object)
+			if(isEventlessUnit(objectUnit)) then
+				oUF:HandleEventlessUnit(object)
 			else
+				-- No need to enable this for eventless units.
+				object:SetAttribute('toggleForVehicle', true)
 				oUF:HandleUnit(object)
 			end
 		else
@@ -333,7 +322,7 @@ local function initObject(unit, style, styleFunc, header, ...)
 			end
 
 			if(suffix == 'target') then
-				enableTargetUpdate(object)
+				oUF:HandleEventlessUnit(object)
 			end
 		end
 

--- a/ouf.lua
+++ b/ouf.lua
@@ -300,12 +300,11 @@ local function initObject(unit, style, styleFunc, header, ...)
 			-- No header means it's a frame created through :Spawn().
 			object:SetAttribute('*type1', 'target')
 			object:SetAttribute('*type2', 'togglemenu')
+			object:SetAttribute('toggleForVehicle', true)
 
 			if(isEventlessUnit(objectUnit)) then
 				oUF:HandleEventlessUnit(object)
 			else
-				-- No need to enable this for eventless units.
-				object:SetAttribute('toggleForVehicle', true)
 				oUF:HandleUnit(object)
 			end
 		else

--- a/ouf.lua
+++ b/ouf.lua
@@ -246,9 +246,9 @@ end
 -- boss6-8 exsist in some encounters, but unit event registration seems to be
 -- completely broken for them, so instead we use OnUpdate to update them.
 local eventlessUnits = {
-	['boss6'] = true,
-	['boss7'] = true,
-	['boss8'] = true,
+	boss6 = true,
+	boss7 = true,
+	boss8 = true,
 }
 
 local function isEventlessUnit(unit)

--- a/units.lua
+++ b/units.lua
@@ -2,7 +2,7 @@ local _, ns = ...
 local oUF = ns.oUF
 local Private = oUF.Private
 
-local enableTargetUpdate = Private.enableTargetUpdate
+local unitExists = Private.unitExists
 
 local function updateArenaPreparationElements(self, event, elementName, specID)
 	local element = self[elementName]
@@ -189,7 +189,53 @@ function oUF:HandleUnit(object, unit)
 		object:SetAttribute('oUF-enableArenaPrep', true)
 		-- the event handler only fires for visible frames, so we have to hook it for arena prep
 		object:HookScript('OnEvent', updateArenaPreparation)
-	elseif(unit:match('%w+target')) then
-		enableTargetUpdate(object)
 	end
+end
+
+local eventlessObjects = {}
+local onUpdates = {}
+
+local function createOnUpdate(timer)
+	if(not onUpdates[timer]) then
+		local frame = CreateFrame('Frame')
+		local objects = eventlessObjects[timer]
+
+		frame:SetScript('OnUpdate', function(self, elapsed)
+			self.elapsed = (self.elapsed or 0) + elapsed
+			if(self.elapsed > timer) then
+				for _, object in next, objects do
+					if(object.unit and unitExists(object.unit)) then
+						object:UpdateAllElements('OnUpdate')
+					end
+				end
+
+				self.elapsed = 0
+			end
+		end)
+
+		onUpdates[timer] = frame
+	end
+end
+
+function oUF:HandleEventlessUnit(object)
+	object.__eventless = true
+
+	local timer = object.onUpdateFrequency or 0.5
+
+	-- Remove it, in case it's registered with another timer previously
+	for t, objects in next, eventlessObjects do
+		if(t ~= timer) then
+			for i, obj in next, objects do
+				if(obj == object) then
+					table.remove(objects, i)
+					break
+				end
+			end
+		end
+	end
+
+	if(not eventlessObjects[timer]) then eventlessObjects[timer] = {} end
+	table.insert(eventlessObjects[timer], object)
+
+	createOnUpdate(timer)
 end

--- a/units.lua
+++ b/units.lua
@@ -220,6 +220,10 @@ end
 function oUF:HandleEventlessUnit(object)
 	object.__eventless = true
 
+	-- It's impossible to set onUpdateFrequency before the frame is created, so
+	-- by default all eventless frames are created with the 0.5s timer.
+	-- To change it you'll need to call oUF:HandleEventlessUnit(frame) one more
+	-- time from the layout code after oUF:Spawn(unit) returns the frame.
 	local timer = object.onUpdateFrequency or 0.5
 
 	-- Remove it, in case it's registered with another timer previously


### PR DESCRIPTION
Had to rework the way we handle eventless or "invalid" units because unlike `"boss1..5"` new `"boss6..8"` units can't be used for `RUE`, it silently fails and falls back to `RE`. The backend seems to be f*cking raw™. Along the way cleaned the code up a bit and fixed a couple of bugs I stumbled upon 😋 

So now instead of using internal `Private.enableTargetUpdate(object)` there's `oUF:HandleEventlessUnit(object)` that can be overridden by users in case they need to do something else in there.

Also, instead of creating a new `OnUpdate` for each frame we now handle eventless unit frames the same way we handle eventless tags, so there's one `OnUpdate` per timer.