### PR TITLE
elements: reference color components by index instead of name

### DIFF
--- a/elements/additionalpower.lua
+++ b/elements/additionalpower.lua
@@ -78,7 +78,7 @@ local function UpdateColor(self, event, unit, powerType)
 	end
 
 	if(color) then
-		r, g, b = color.r, color.g, color.b
+		r, g, b = color[1], color[2], color[3]
 	end
 
 	if(b) then

--- a/elements/alternativepower.lua
+++ b/elements/alternativepower.lua
@@ -101,7 +101,7 @@ local function UpdateColor(self, event, unit, powerType)
 	end
 
 	if(color) then
-		r, g, b = color.r, color.g, color.b
+		r, g, b = color[1], color[2], color[3]
 	end
 
 	if(b) then

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -215,7 +215,7 @@ local function updateIcon(element, unit, index, offset, filter, isDebuff, visibl
 				if((isDebuff and element.showDebuffType) or (not isDebuff and element.showBuffType) or element.showType) then
 					local color = element.__owner.colors.debuff[debuffType] or element.__owner.colors.debuff.none
 
-					button.overlay:SetVertexColor(color.r, color.g, color.b)
+					button.overlay:SetVertexColor(color[1], color[2], color[3])
 					button.overlay:Show()
 				else
 					button.overlay:Hide()

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -67,7 +67,7 @@ local RequireSpec, RequirePower, RequireSpell
 
 local function UpdateColor(element, powerType)
 	local color = element.__owner.colors.power[powerType]
-	local r, g, b = color.r, color.g, color.b
+	local r, g, b = color[1], color[2], color[3]
 	for i = 1, #element do
 		local bar = element[i]
 		bar:SetStatusBarColor(r, g, b)

--- a/elements/health.lua
+++ b/elements/health.lua
@@ -109,7 +109,7 @@ local function UpdateColor(self, event, unit)
 	end
 
 	if(color) then
-		r, g, b = color.r, color.g, color.b
+		r, g, b = color[1], color[2], color[3]
 	end
 
 	if(b) then

--- a/elements/power.lua
+++ b/elements/power.lua
@@ -161,7 +161,7 @@ local function UpdateColor(self, event, unit)
 	end
 
 	if(color) then
-		r, g, b = color.r, color.g, color.b
+		r, g, b = color[1], color[2], color[3]
 	end
 
 	if(b) then

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -92,7 +92,7 @@ local function UpdateColor(self, event)
 		color = self.colors.power.RUNES
 	end
 
-	local r, g, b = color.r, color.g, color.b
+	local r, g, b = color[1], color[2], color[3]
 
 	for index = 1, #element do
 		element[index]:SetStatusBarColor(r, g, b)

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -67,7 +67,7 @@ local function UpdateColor(self, event, unit)
 
 	local r, g, b
 	if(color) then
-		r, g, b = color.r, color.g, color.b
+		r, g, b = color[1], color[2], color[3]
 		if(b) then
 			element:SetStatusBarColor(r, g, b)
 

--- a/elements/threatindicator.lua
+++ b/elements/threatindicator.lua
@@ -62,7 +62,7 @@ local function Update(self, event, unit)
 	local r, g, b
 	if(status and status > 0) then
 		local color = self.colors.threat[status]
-		r, g, b = color.r, color.g, color.b
+		r, g, b = color[1], color[2], color[3]
 
 		if(element.SetVertexColor) then
 			element:SetVertexColor(r, g, b)

--- a/units.lua
+++ b/units.lua
@@ -61,7 +61,7 @@ local function updateArenaPreparationElements(self, event, elementName, specID)
 			end
 
 			if(color) then
-				r, g, b = color.r, color.g, color.b
+				r, g, b = color[1], color[2], color[3]
 			end
 
 			if(r or g or b) then


### PR DESCRIPTION
Layouts using metatables to override default colors might not have named components.
This is partial revert of da7554aa.