### PR TITLE
core: Run UAE on UEV

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -285,8 +285,8 @@ local function initObject(unit, style, styleFunc, header, ...)
 		object:RegisterEvent('PLAYER_ENTERING_WORLD', evalUnitAndUpdate, true)
 
 		if(not isEventlessUnit(objectUnit)) then
-			object:RegisterEvent('UNIT_ENTERED_VEHICLE', updateActiveUnit)
-			object:RegisterEvent('UNIT_EXITED_VEHICLE', updateActiveUnit)
+			object:RegisterEvent('UNIT_ENTERED_VEHICLE', evalUnitAndUpdate)
+			object:RegisterEvent('UNIT_EXITED_VEHICLE', evalUnitAndUpdate)
 
 			-- We don't need to register UNIT_PET for the player unit. We register it
 			-- mainly because UNIT_EXITED_VEHICLE and UNIT_ENTERED_VEHICLE don't always


### PR DESCRIPTION
Vehicle events fire when the player not only enters/exits a vehicle, but also when the player changes sits. In this case both units on the unit frame will stay the same, so `UAE` won't be called which in turn leaves the frame with outdated info.

![image](https://user-images.githubusercontent.com/2725970/161600533-5e7f812a-1015-429c-81f6-cdba92a15bb5.png)

We need to run `UAE` so the frame updates properly.