### PR TITLE
Add alpha to UpdateColor for health

### DIFF
--- a/elements/health.lua
+++ b/elements/health.lua
@@ -87,6 +87,7 @@ local function UpdateColor(self, event, unit)
 	local element = self.Health
 
 	local r, g, b, color
+	local _, _, _, a = self.Health:GetStatusBarColor()
 	if(element.colorDisconnected and not UnitIsConnected(unit)) then
 		color = self.colors.disconnected
 	elseif(element.colorTapping and not UnitPlayerControlled(unit) and UnitIsTapDenied(unit)) then
@@ -113,7 +114,7 @@ local function UpdateColor(self, event, unit)
 	end
 
 	if(b) then
-		element:SetStatusBarColor(r, g, b)
+		element:SetStatusBarColor(r, g, b, a)
 
 		local bg = element.bg
 		if(bg) then


### PR DESCRIPTION
I originally raised the [issue ](https://github.com/oUF-wow/oUF/issues/611) that the alpha is overwritten in the UpdateColor function leading to issues if you want to lower the alpha of just the StatusBar instead of the entire Health frame.

The problem causes behavior as seen in this gif where, upon every call of UpdateColor, the frame shortly resets to `Alpha = 1` before being reset to the desired value.
![blink](https://user-images.githubusercontent.com/33216468/182028112-bf627791-03d9-4569-b26a-1d1606041807.gif)

The solution is relatively simple. Before setting the color of the StatusBar in the UpdateColor function, you get the current alpha and reapply it to bar when updating.
