### PR TITLE
blizzard: Properly disable party frames

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -31,6 +31,7 @@ read_globals = {
 	'Mixin',
 	'MonkStaggerBar',
 	'NamePlateDriverFrame',
+	'PartyFrame',
 	'PetCastingBarFrame',
 	'PetCastingBarFrame_OnLoad',
 	'PetFrame',

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -7,8 +7,7 @@ local MAX_ARENA_ENEMIES = _G.MAX_ARENA_ENEMIES or 5
 -- sourced from FrameXML/TargetFrame.lua
 local MAX_BOSS_FRAMES = _G.MAX_BOSS_FRAMES or 5
 
--- sourced from FrameXML/PartyMemberFrame.lua
-local MAX_PARTY_MEMBERS = _G.MAX_PARTY_MEMBERS or 4
+local isPartyHooked = false
 
 local hiddenParent = CreateFrame('Frame', nil, UIParent)
 hiddenParent:SetAllPoints()
@@ -34,12 +33,12 @@ local function handleFrame(baseName, doNotReparent)
 			frame:SetParent(hiddenParent)
 		end
 
-		local health = frame.healthBar or frame.healthbar
+		local health = frame.healthBar or frame.healthbar or frame.HealthBar
 		if(health) then
 			health:UnregisterAllEvents()
 		end
 
-		local power = frame.manabar
+		local power = frame.manabar or frame.ManaBar
 		if(power) then
 			power:UnregisterAllEvents()
 		end
@@ -49,7 +48,7 @@ local function handleFrame(baseName, doNotReparent)
 			spell:UnregisterAllEvents()
 		end
 
-		local altpowerbar = frame.powerBarAlt
+		local altpowerbar = frame.powerBarAlt or frame.PowerBarAlt
 		if(altpowerbar) then
 			altpowerbar:UnregisterAllEvents()
 		end
@@ -57,6 +56,11 @@ local function handleFrame(baseName, doNotReparent)
 		local buffFrame = frame.BuffFrame
 		if(buffFrame) then
 			buffFrame:UnregisterAllEvents()
+		end
+
+		local petFrame = frame.PetFrame
+		if(petFrame) then
+			petFrame:UnregisterAllEvents()
 		end
 	end
 end
@@ -97,12 +101,13 @@ function oUF:DisableBlizzard(unit)
 			end
 		end
 	elseif(unit:match('party%d?$')) then
-		local id = unit:match('party(%d)')
-		if(id) then
-			handleFrame('PartyMemberFrame' .. id)
-		else
-			for i = 1, MAX_PARTY_MEMBERS do
-				handleFrame(string.format('PartyMemberFrame%d', i))
+		if(not isPartyHooked) then
+			isPartyHooked = true
+
+			PartyFrame:UnregisterAllEvents()
+
+			for frame in PartyFrame.PartyMemberFramePool:EnumerateActive() do
+				handleFrame(frame)
 			end
 		end
 	elseif(unit:match('arena%d?$')) then

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -62,6 +62,11 @@ local function handleFrame(baseName, doNotReparent)
 		if(petFrame) then
 			petFrame:UnregisterAllEvents()
 		end
+
+		local totFrame = frame.totFrame
+		if(totFrame) then
+			totFrame:UnregisterAllEvents()
+		end
 	end
 end
 
@@ -88,9 +93,6 @@ function oUF:DisableBlizzard(unit)
 		handleFrame(ComboFrame)
 	elseif(unit == 'focus') then
 		handleFrame(FocusFrame)
-		handleFrame(TargetofFocusFrame)
-	elseif(unit == 'targettarget') then
-		handleFrame(TargetFrameToT)
 	elseif(unit:match('boss%d?$')) then
 		local id = unit:match('boss(%d)')
 		if(id) then

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -90,7 +90,6 @@ function oUF:DisableBlizzard(unit)
 		handleFrame(PetFrame)
 	elseif(unit == 'target') then
 		handleFrame(TargetFrame)
-		handleFrame(ComboFrame)
 	elseif(unit == 'focus') then
 		handleFrame(FocusFrame)
 	elseif(unit:match('boss%d?$')) then


### PR DESCRIPTION
Blizz reworked how their party frames work, they now use pools. Boss frames still work the old way, btw, no need to change anything there.