### PR TITLE
blizzard: Properly disable arena frames

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,6 +21,9 @@ read_globals = {
 	table = {fields = {'removemulti', 'wipe'}},
 
 	-- FrameXML
+	'ArenaEnemyFramesContainer',
+	'ArenaEnemyMatchFramesContainer',
+	'ArenaEnemyPrepFramesContainer',
 	'ColorMixin',
 	'ComboFrame',
 	'CreateColor',

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -99,7 +99,7 @@ function oUF:DisableBlizzard(unit)
 			handleFrame('Boss' .. id .. 'TargetFrame')
 		else
 			for i = 1, MAX_BOSS_FRAMES do
-				handleFrame(string.format('Boss%dTargetFrame', i))
+				handleFrame('Boss' .. i .. 'TargetFrame')
 			end
 		end
 	elseif(unit:match('party%d?$')) then

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -7,6 +7,7 @@ local MAX_ARENA_ENEMIES = _G.MAX_ARENA_ENEMIES or 5
 -- sourced from FrameXML/TargetFrame.lua
 local MAX_BOSS_FRAMES = _G.MAX_BOSS_FRAMES or 5
 
+local isArenaHooked = false
 local isPartyHooked = false
 
 local hiddenParent = CreateFrame('Frame', nil, UIParent)
@@ -58,7 +59,7 @@ local function handleFrame(baseName, doNotReparent)
 			buffFrame:UnregisterAllEvents()
 		end
 
-		local petFrame = frame.PetFrame
+		local petFrame = frame.petFrame or frame.PetFrame
 		if(petFrame) then
 			petFrame:UnregisterAllEvents()
 		end
@@ -112,17 +113,23 @@ function oUF:DisableBlizzard(unit)
 			end
 		end
 	elseif(unit:match('arena%d?$')) then
-		local id = unit:match('arena(%d)')
-		if(id) then
-			handleFrame('ArenaEnemyMatchFrame' .. id)
-		else
+		if(not isArenaHooked) then
+			isArenaHooked = true
+
+			-- this disables ArenaEnemyFramesContainer
+			SetCVar('showArenaEnemyFrames', '0')
+			SetCVar('showArenaEnemyPets', '0')
+
+			-- but still UAE all containers
+			ArenaEnemyFramesContainer:UnregisterAllEvents()
+			ArenaEnemyPrepFramesContainer:UnregisterAllEvents()
+			ArenaEnemyMatchFramesContainer:UnregisterAllEvents()
+
 			for i = 1, MAX_ARENA_ENEMIES do
-				handleFrame(string.format('ArenaEnemyMatchFrame%d', i))
+				handleFrame('ArenaEnemyMatchFrame' .. i)
+				handleFrame('ArenaEnemyPrepFrame' .. i)
 			end
 		end
-
-		-- this disables ArenaEnemyFramesContainer
-		SetCVar('showArenaEnemyFrames', '0')
 	elseif(unit:match('nameplate%d+$')) then
 		local frame = C_NamePlate.GetNamePlateForUnit(unit)
 		if(frame and frame.UnitFrame) then


### PR DESCRIPTION
Currently it doesn't disable arena prep frames, this PR addressed that.

I was thinking about reformatting the boss block as well, but its container doesn't do anything smart, so I left it as is. I still removed that `string.format` call. Why was it there?