### PR TITLE
Additional aura element overrides/callbacks

### DIFF
--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -275,13 +275,14 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 	local auras = self.Auras
 	if(auras) then
-		--[[ Callback: Auras:PreUpdate(unit)
+		--[[ Callback: Auras:PreUpdate(unit, updateInfo)
 		Called before the element has been updated.
 
-		* self - the widget holding the aura buttons
-		* unit - the unit for which the update has been triggered (string)
+		* self       - the widget holding the aura buttons
+		* unit       - the unit for which the update has been triggered (string)
+		* updateInfo - [UnitAuraUpdateInfo](https://wowpedia.fandom.com/wiki/UNIT_AURA) object (table)
 		--]]
-		if(auras.PreUpdate) then auras:PreUpdate(unit) end
+		if(auras.PreUpdate) then auras:PreUpdate(unit, updateInfo) end
 
 		local buffsChanged = false
 		local numBuffs = auras.numBuffs or 32
@@ -530,7 +531,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 	local buffs = self.Buffs
 	if(buffs) then
-		if(buffs.PreUpdate) then buffs:PreUpdate(unit) end
+		if(buffs.PreUpdate) then buffs:PreUpdate(unit, updateInfo) end
 
 		local buffsChanged = false
 		local numBuffs = buffs.num or 32
@@ -628,7 +629,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 	local debuffs = self.Debuffs
 	if(debuffs) then
-		if(debuffs.PreUpdate) then debuffs:PreUpdate(unit) end
+		if(debuffs.PreUpdate) then debuffs:PreUpdate(unit, updateInfo) end
 
 		local debuffsChanged = false
 		local numDebuffs = debuffs.num or 40

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -508,7 +508,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 			if(auras.createdButtons > auras.anchoredButtons) then
 				--[[ Override: Auras:SetPosition(from, to)
 				Used to (re-)anchor the aura buttons.
-				Called when new aura buttons have been created or if :PreSetPosition is defined.
+				Called when new aura buttons have been created.
 
 				* self - the widget that holds the aura buttons
 				* from - the offset of the first aura button to be (re-)anchored (number)

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -418,6 +418,14 @@ local function UpdateAuras(self, event, unit, updateInfo)
 		end
 
 		if(buffsChanged or debuffsChanged) then
+			--[[ Callback: Auras:PreSort(unit)
+			Called before ordering the auras.
+
+			* self - the widget holding the aura buttons
+			* unit - the unit for which the update has been triggered (string)
+			--]]
+			if(auras.PreSort) then auras:PreSort(unit) end
+
 			if(buffsChanged) then
 				-- instead of removing auras one by one, just wipe the tables entirely
 				-- and repopulate them, multiple table.remove calls are insanely slow
@@ -604,6 +612,8 @@ local function UpdateAuras(self, event, unit, updateInfo)
 		if(buffsChanged) then
 			buffs.sorted = table.wipe(buffs.sorted or {})
 
+			if(buffs.PreSort) then buffs:PreSort(unit) end
+
 			for _, data in next, buffs.active do
 				table.insert(buffs.sorted, data)
 			end
@@ -701,6 +711,8 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 		if(debuffsChanged) then
 			debuffs.sorted = table.wipe(debuffs.sorted or {})
+
+			if(debuffs.PreSort) then debuffs:PreSort(unit) end
 
 			for _, data in next, debuffs.active do
 				table.insert(debuffs.sorted, data)


### PR DESCRIPTION
In SL I was using a combination of callbacks and overrides to display dispellable debuffs nice and big in the middle of my raid frames. I've also used this to display defensive buffs in the top right of my raid frames

The available callback/override points in the aura element for SL were enough to implement this. With the aura element changes for DF (which are great btw :)) the only option I see to reimplement this somewhat cleanly is by the proposed changes in 2a2598f4a7011435c8fa3a5b45bebe8f352ee9aa and eb6e77860a2fbee471785e17530e48be413b0dc8.

- commit eb6e77860a2fbee471785e17530e48be413b0dc8
Allows me to do some cleanup on my internal variables if the update is going to be a full update

- commit 2a2598f4a7011435c8fa3a5b45bebe8f352ee9aa
Allows me to temporarily modify the debuffs that will be displayed. I can remove the one debuff  I'll be displaying in my own special frame via instanceID and add it back to `.active` in `PostUpdate()`.

This is how it looks:
![image](https://user-images.githubusercontent.com/6280154/199806407-d65d88a6-b00a-4e38-8de4-a9bb5a3e8e56.png)
Bottom left: Normal debuffs (space for 3 total)
Center: Special debuffs (currently only dispellable)
Top Right (Bonus): Using the logic to display blizzard dispell debuf icon

Any thoughts on this?