### PR TITLE
auras: element fixes and additions

### DIFF
--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -275,13 +275,14 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 	local auras = self.Auras
 	if(auras) then
-		--[[ Callback: Auras:PreUpdate(unit)
+		--[[ Callback: Auras:PreUpdate(unit, updateInfo)
 		Called before the element has been updated.
 
-		* self - the widget holding the aura buttons
-		* unit - the unit for which the update has been triggered (string)
+		* self       - the widget holding the aura buttons
+		* unit       - the unit for which the update has been triggered (string)
+		* updateInfo - [UnitAuraUpdateInfo](https://wowpedia.fandom.com/wiki/UNIT_AURA) object (table)
 		--]]
-		if(auras.PreUpdate) then auras:PreUpdate(unit) end
+		if(auras.PreUpdate) then auras:PreUpdate(unit, updateInfo) end
 
 		local buffsChanged = false
 		local numBuffs = auras.numBuffs or 32
@@ -530,7 +531,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 	local buffs = self.Buffs
 	if(buffs) then
-		if(buffs.PreUpdate) then buffs:PreUpdate(unit) end
+		if(buffs.PreUpdate) then buffs:PreUpdate(unit, updateInfo) end
 
 		local buffsChanged = false
 		local numBuffs = buffs.num or 32
@@ -628,7 +629,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 	local debuffs = self.Debuffs
 	if(debuffs) then
-		if(debuffs.PreUpdate) then debuffs:PreUpdate(unit) end
+		if(debuffs.PreUpdate) then debuffs:PreUpdate(unit, updateInfo) end
 
 		local debuffsChanged = false
 		local numDebuffs = debuffs.num or 40

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -508,7 +508,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 			if(auras.createdButtons > auras.anchoredButtons) then
 				--[[ Override: Auras:SetPosition(from, to)
 				Used to (re-)anchor the aura buttons.
-				Called when new aura buttons have been created or if :PreSetPosition is defined.
+				Called when new aura buttons have been created.
 
 				* self - the widget that holds the aura buttons
 				* from - the offset of the first aura button to be (re-)anchored (number)

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -381,6 +381,16 @@ local function UpdateAuras(self, event, unit, updateInfo)
 			end
 		end
 
+		--[[ Callback: Auras:PostUpdateInfo(unit, changed, updateInfo)
+		Called after updating the info for the active auras.
+
+		* self       - the widget holding the aura buttons
+		* unit       - the unit for which the update has been triggered (string)
+		* changed    - the hint on whether information was changed (boolean)
+		* updateInfo - [UnitAuraUpdateInfo](https://wowpedia.fandom.com/wiki/UNIT_AURA) object (table)
+		--]]
+		if(auras.PostUpdateInfo) then auras:PostUpdateInfo(unit, buffsChanged or debuffsChanged, updateInfo) end
+
 		if(buffsChanged or debuffsChanged) then
 
 			local numDebuffs = auras.numDebuffs or 40
@@ -557,6 +567,8 @@ local function UpdateAuras(self, event, unit, updateInfo)
 			end
 		end
 
+		if(buffs.PostUpdateInfo) then buffs:PostUpdateInfo(unit, buffsChanged, updateInfo) end
+
 		if(buffsChanged) then
 			local numBuffs = buffs.num or 32
 			buffs.sorted = table.wipe(buffs.sorted or {})
@@ -639,6 +651,8 @@ local function UpdateAuras(self, event, unit, updateInfo)
 				end
 			end
 		end
+
+		if(debuffs.PostUpdateInfo) then debuffs:PostUpdateInfo(unit, debuffsChanged, updateInfo) end
 
 		if(debuffsChanged) then
 			local numDebuffs = debuffs.num or 40


### PR DESCRIPTION
PR as draft, not the lua expert. Feel free to use as inspiration or take what you feel would be beneficial. Tried to keep my additions, fixes and wishes as separate commits for easier cherry-picking.

ead3964b2fea1e74bd9ec462a3c514d00058e032 fixes what we were talking about, with having to track more auras than we are actually showing. Else when one of the showing auras disappear we won't have a aura to fill the gap. 

To test:
1. create a aura element with a small aura.num, say 3-4.
2. Buff yourself to like 4+ buffs
3. click of one the buffs that are currently being shown in the aura element
4. notice that even though there are still 4+ buffs active in the blizzard default player buff bar
5. The empty spot in your aura element is not filled by another aura

