### PR TITLE
Fix ComboFramePlayer error on druid login

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -76,6 +76,7 @@ function oUF:DisableBlizzard(unit)
 
 	if(unit == 'player') then
 		handleFrame(PlayerFrame)
+		handleFrame(ComboPointDruidPlayerFrame)
 
 		-- For the damn vehicle support:
 		PlayerFrame:RegisterEvent('PLAYER_ENTERING_WORLD')


### PR DESCRIPTION
Fix the following error:
```
Message: Interface/FrameXML/ComboFramePlayer.lua:17: Usage: local power = UnitPower(unitToken [, powerType, unmodified])
Time: Sat Nov 12 14:09:39 2022
Count: 1
Stack: Interface/FrameXML/ComboFramePlayer.lua:17: Usage: local power = UnitPower(unitToken [, powerType, unmodified])
[string "=[C]"]: ?
[string "=[C]"]: in function `UnitPower'
[string "@Interface/FrameXML/ComboFramePlayer.lua"]:17: in function `UpdatePower'
[string "@Interface/FrameXML/ClassPowerBar.lua"]:58: in function `OnEvent'
[string "@Interface/FrameXML/ClassResourceBarTemplate.lua"]:58: in function <Interface/FrameXML/ClassResourceBarTemplate.lua:38>

Locals: 
```

Which seems to be related to druids having a new/different blizzard combo frame.

I also tried tinkered with `handleFrame(ComboPointPlayerFrame)`, but that doesn't seem to add any benefit. Rogues work okay even without that on my implementation at least.