### PR TITLE
auras: Update element

### DIFF
--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -480,7 +480,7 @@ local function UpdateAuras(self, event, unit, updateInfo)
 
 			local offset = #auras.sortedBuffs
 
-			if(auras.gap and #auras.sortedDebuffs > 0) then
+			if(auras.gap and offset > 0 and #auras.sortedDebuffs > 0) then
 				offset = offset + 1
 
 				local button = auras[offset]


### PR DESCRIPTION
This one addresses #620 and #621 and some other concerns brought up in [our subforum on wowi](https://www.wowinterface.com/forums/showthread.php?t=59334).

I updated the update process so that it properly fills in the blank spots when possible. There's new `.all`, `.allBuffs`, and `.allDebuffs` to keep track of all auras that aren't filtered out by `.filter`, `.buffFilter`, or `.debuffFilter`. `.active` tables no longer carry any aura data, that's what `.all` is for, `.active`s are just lists of active auras. `.sorted` tables are unchanged.

I also added the new `.redrawIfVisibleChanged` option. In some cases, for instance, nameplates users want to redraw the buttons whenever the number of visible buttons changes, this option will allow them to do exactly that.