### PR TITLE
Investigate switching to UPU from UPF for class powers

### DIFF
--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -255,7 +255,7 @@ end
 do
 	function ClassPowerEnable(self)
 		self:RegisterEvent('UNIT_MAXPOWER', Path)
-		self:RegisterEvent('UNIT_POWER_FREQUENT', Path)
+		self:RegisterEvent('UNIT_POWER_UPDATE', Path)
 
 		-- according to Blizz any class may receive this event due to specific spell auras
 		self:RegisterEvent('UNIT_POWER_POINT_CHARGE', Path)
@@ -270,7 +270,7 @@ do
 	end
 
 	function ClassPowerDisable(self)
-		self:UnregisterEvent('UNIT_POWER_FREQUENT', Path)
+		self:UnregisterEvent('UNIT_POWER_UPDATE', Path)
 		self:UnregisterEvent('UNIT_MAXPOWER', Path)
 		self:UnregisterEvent('UNIT_POWER_POINT_CHARGE', Path)
 


### PR DESCRIPTION
UPF is a very spammy event, and using it for something like class powers feels like an overkill. They simply don't continuously regen like , let's say, rogue's Energy. The only reason why we use UPF is because it's been this way for over a decade at this point 😒

I'm not sure if there's any drawbacks to using UPU hence the name of the PR. I'll switch my own UI to UPU to gather as much feedback as possible from its users, but help from others is always welcome 😊