### PR TITLE
Remove problematic legacy code

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -76,17 +76,6 @@ function oUF:DisableBlizzard(unit)
 
 	if(unit == 'player') then
 		handleFrame(PlayerFrame)
-
-		-- For the damn vehicle support:
-		PlayerFrame:RegisterEvent('PLAYER_ENTERING_WORLD')
-		PlayerFrame:RegisterEvent('UNIT_ENTERING_VEHICLE')
-		PlayerFrame:RegisterEvent('UNIT_ENTERED_VEHICLE')
-		PlayerFrame:RegisterEvent('UNIT_EXITING_VEHICLE')
-		PlayerFrame:RegisterEvent('UNIT_EXITED_VEHICLE')
-
-		-- User placed frames don't animate
-		PlayerFrame:SetUserPlaced(true)
-		PlayerFrame:SetDontSavePosition(true)
 	elseif(unit == 'pet') then
 		handleFrame(PetFrame)
 	elseif(unit == 'target') then

--- a/blizzard.lua
+++ b/blizzard.lua
@@ -68,6 +68,11 @@ local function handleFrame(baseName, doNotReparent)
 		if(totFrame) then
 			totFrame:UnregisterAllEvents()
 		end
+
+		local classPowerBar = frame.classPowerBar
+		if(classPowerBar) then
+			classPowerBar:UnregisterAllEvents()
+		end
 	end
 end
 


### PR DESCRIPTION
I did Oculus and Malygos with this and didn't get any taints or see any issues whatsoever.

The source from the extra PlayerFrame events are from 2010 (Wrath):
- https://github.com/oUF-wow/oUF/commit/4d66082e6be7727ccc4b9489de1164809a515dea
- https://github.com/oUF-wow/oUF/commit/03eb8217d5c4a4a7ca8384b623da24afb78ad533

Fixes #622 