### PR TITLE
core: Update nameplate hook

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -155,15 +155,17 @@ function oUF:DisableBlizzard(unit)
 				handleFrame('ArenaEnemyPrepFrame' .. i, true)
 			end
 		end
-	elseif(unit:match('nameplate%d+$')) then
-		local frame = C_NamePlate.GetNamePlateForUnit(unit)
-		if(frame and frame.UnitFrame) then
-			if(not frame.UnitFrame.isHooked) then
-				frame.UnitFrame:HookScript('OnShow', insecureOnShow)
-				frame.UnitFrame.isHooked = true
-			end
-
-			handleFrame(frame.UnitFrame, true)
-		end
 	end
+end
+
+function oUF:DisableNamePlate(frame)
+	if(not(frame or frame.UnitFrame)) then return end
+	if(frame.UnitFrame:IsForbidden()) then return end
+
+	if(not frame.UnitFrame.isHooked) then
+		frame.UnitFrame:HookScript('OnShow', insecureOnShow)
+		frame.UnitFrame.isHooked = true
+	end
+
+	handleFrame(frame.UnitFrame, true)
 end

--- a/ouf.lua
+++ b/ouf.lua
@@ -764,10 +764,8 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 	-- and because forbidden nameplates exist, we have to allow default nameplate
 	-- driver to create, update, and remove Blizz nameplates.
 	-- Disable only not forbidden nameplates.
-	NamePlateDriverFrame:HookScript('OnEvent', function(_, event, unit)
-		if(event == 'NAME_PLATE_UNIT_ADDED' and unit) then
-			self:DisableBlizzard(unit)
-		end
+	hooksecurefunc(NamePlateDriverFrame, 'AcquireUnitFrame', function(...)
+		self:DisableNamePlate(...)
 	end)
 
 	local eventHandler = CreateFrame('Frame', 'oUF_NamePlateDriver')


### PR DESCRIPTION
This one reduces our footprint. Because we hooked the `OnEvent` handler oUF got EVERYTHING that's happening in and because of that function attributed to it. So in addons like ACU we'd get hugely inflated numbers without actually doing anything at all 😒🔫

Before:
![image](https://user-images.githubusercontent.com/2725970/223487066-fa94d412-7951-43d7-84ad-4d6ff04fb160.png)

After:
![image](https://user-images.githubusercontent.com/2725970/223487130-0e8e67d6-26c1-4cd0-a818-9f8d6e22a3e4.png)

"Free performance" 🤣 Just to be clear, there's no actual performance improvement in this PR. It's just a quirk of how function hooking works.