### PR TITLE
tags: Adjust eventTimerThreshold

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -603,7 +603,7 @@ eventFrame:SetScript('OnEvent', function(self, event, unit)
 end)
 
 local eventTimer = 0
-local eventTimerThreshold = 0.25
+local eventTimerThreshold = 0.1
 
 eventFrame:SetScript('OnUpdate', function(self, elapsed)
 	eventTimer = eventTimer + elapsed
@@ -983,7 +983,7 @@ oUF.Tags = {
 		if(not timer) then return end
 		if(not type(timer) == 'number') then return end
 
-		eventTimerThreshold = math.max(0.1, timer)
+		eventTimerThreshold = math.max(0.05, timer)
 	end,
 }
 


### PR DESCRIPTION
After experimenting for a bit, I decided to adjust these values to allow for greater smoothness.

![text_update_test](https://user-images.githubusercontent.com/2725970/235714295-21d26654-dd7c-4462-9a84-f3ae6840d262.gif)

There's very little difference below 0.06s, but it's such an odd value that I picked 0.05s as the new minimum.