### PR TITLE
NamePlate fixes

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -11,6 +11,7 @@ local MAX_BOSS_FRAMES = _G.MAX_BOSS_FRAMES or 5
 local MEMBERS_PER_RAID_GROUP = _G.MEMBERS_PER_RAID_GROUP or 5
 
 local hookedFrames = {}
+local hookedNameplates = {}
 local isArenaHooked = false
 local isBossHooked = false
 local isPartyHooked = false
@@ -19,7 +20,7 @@ local hiddenParent = CreateFrame('Frame', nil, UIParent)
 hiddenParent:SetAllPoints()
 hiddenParent:Hide()
 
-local function insecureOnShow(self)
+local function insecureHide(self)
 	self:Hide()
 end
 
@@ -162,9 +163,10 @@ function oUF:DisableNamePlate(frame)
 	if(not(frame and frame.UnitFrame)) then return end
 	if(frame.UnitFrame:IsForbidden()) then return end
 
-	if(not frame.UnitFrame.isHooked) then
-		frame.UnitFrame:HookScript('OnShow', insecureOnShow)
-		frame.UnitFrame.isHooked = true
+	if(not hookedNameplates[frame]) then
+		frame.UnitFrame:HookScript('OnShow', insecureHide)
+
+		hookedNameplates[frame] = true
 	end
 
 	handleFrame(frame.UnitFrame, true)

--- a/ouf.lua
+++ b/ouf.lua
@@ -819,6 +819,18 @@ function oUF:SpawnNamePlates(namePrefix, nameplateCallback, nameplateCVars)
 
 			nameplate.unitFrame:SetAttribute('unit', unit)
 
+			if(nameplate.UnitFrame) then
+				if(nameplate.UnitFrame.WidgetContainer) then
+					nameplate.UnitFrame.WidgetContainer:SetParent(nameplate.unitFrame)
+					nameplate.unitFrame.WidgetContainer = nameplate.UnitFrame.WidgetContainer
+				end
+
+				if(nameplate.UnitFrame.SoftTargetFrame) then
+					nameplate.UnitFrame.SoftTargetFrame:SetParent(nameplate.unitFrame)
+					nameplate.unitFrame.SoftTargetFrame = nameplate.UnitFrame.SoftTargetFrame
+				end
+			end
+
 			if(nameplateCallback) then
 				nameplateCallback(nameplate.unitFrame, event, unit)
 			end


### PR DESCRIPTION
That `.isHooked` thingy was kinda gaudy, we don't do that anymore.

Also finally added widget and soft target containers to our nameplates. Better late than never.