### PR TITLE
castbar: Improve empowered cast handling

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -173,6 +173,16 @@ local function UpdatePips(element, numStages)
 			end
 		end
 	end
+
+	--[[ Callback: Castbar:PostUpdatePips(unit)
+	Called after the element has updated stage separators (pips) in an empowered cast.
+
+	* self - the Castbar widget
+	* numStages - the number of stages in the current cast (number)
+	--]]
+	if(element.PostUpdatePips) then
+		element:PostUpdatePips(numStages)
+	end
 end
 
 local function CastStart(self, event, unit)

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -502,7 +502,7 @@ local function Enable(self, unit)
 		self:RegisterEvent('UNIT_SPELLCAST_NOT_INTERRUPTIBLE', CastInterruptible)
 
 		element.holdTime = 0
-		element.Pips = {}
+		element.Pips = element.Pips or {}
 
 		element:SetScript('OnUpdate', element.OnUpdate or onUpdate)
 

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -37,7 +37,7 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 .numStages        - The number of empowerment stages of the current spell (number?)
 .curStage         - The current empowerment stage of the spell. It updates only if the PostUpdateStage callback is
                     defined (number?)
-.stagePoints      - The timestamps (in seconds) for each empowerment stage (table?)
+.stagePoints      - The timestamps (in seconds) for each empowerment stage (table)
 
 ## Examples
 
@@ -185,7 +185,7 @@ local function UpdatePips(element, numStages)
 		end
 	end
 
-	--[[ Callback: Castbar:PostUpdatePips(unit)
+	--[[ Callback: Castbar:PostUpdatePips(numStages)
 	Called after the element has updated stage separators (pips) in an empowered cast.
 
 	* self - the Castbar widget

--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -34,6 +34,10 @@ A default texture will be applied to the StatusBar and Texture widgets if they d
 .empowering       - Indicates whether the current spell is an empowering cast (boolean)
 .notInterruptible - Indicates whether the current spell is interruptible (boolean)
 .spellID          - The spell identifier of the currently cast/channeled/empowering spell (number)
+.numStages        - The number of empowerment stages of the current spell (number?)
+.curStage         - The current empowerment stage of the spell. It updates only if the PostUpdateStage callback is
+                    defined (number?)
+.stagePoints      - The timestamps (in seconds) for each empowerment stage (table?)
 
 ## Examples
 


### PR DESCRIPTION
Empowered casts needed some love.

First of all, I added missing `PostUpdatePips` callback, users basically had no other option, but to override `CreatePips` and then jump through the hoops in `PostCastStart`.

Secondly, I added `PostUpdateStage` to notify the layout whenever the current stage changes.