### PR TITLE
core: Support contextual pings

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -37,6 +37,7 @@ read_globals = {
 	'PartyFrame',
 	'PetCastingBarFrame',
 	'PetFrame',
+	'PingableType_UnitFrameMixin',
 	'PlayerCastingBarFrame',
 	'PlayerFrame',
 	'PlayerPowerBarAlt',

--- a/ouf.lua
+++ b/ouf.lua
@@ -361,6 +361,17 @@ local function walkObject(object, unit)
 
 	local header = parent:GetAttribute('oUF-headerType') and parent
 
+	--[[ frame.IsPingable
+	This boolean can be set to false to disable the frame from being pingable. Enabled by default.
+	--]]
+	--[[ Override: frame:GetContextualPingType()
+	Used to define which contextual ping is used for the frame.
+
+	By default this wraps `C_Ping.GetContextualPingTypeForUnit(UnitGUID(frame.unit))`.
+	--]]
+	object:SetAttribute('ping-receiver', true)
+	Mixin(object, PingableType_UnitFrameMixin)
+
 	-- Check if we should leave the main frame blank.
 	if(object:GetAttribute('oUF-onlyProcessChildren')) then
 		object.hasChildren = true


### PR DESCRIPTION
They can be disabled in other ways than setting `frame.IsPingable = false`, but it's the simplest way (other methods involve attributes).