### PR TITLE
core: Fix contextual ping on header children

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -302,6 +302,16 @@ local function initObject(unit, style, styleFunc, header, ...)
 			object:SetAttribute('*type2', 'togglemenu')
 			object:SetAttribute('toggleForVehicle', true)
 
+			--[[ frame.IsPingable
+			This boolean can be set to false to disable the frame from being pingable. Enabled by default.
+			--]]
+			--[[ Override: frame:GetContextualPingType()
+			Used to define which contextual ping is used for the frame.
+
+			By default this wraps `C_Ping.GetContextualPingTypeForUnit(UnitGUID(frame.unit))`.
+			--]]
+			object:SetAttribute('ping-receiver', true)
+
 			if(isEventlessUnit(objectUnit)) then
 				oUF:HandleEventlessUnit(object)
 			else
@@ -346,15 +356,6 @@ local function initObject(unit, style, styleFunc, header, ...)
 			func(object)
 		end
 
-		--[[ frame.IsPingable
-		This boolean can be set to false to disable the frame from being pingable. Enabled by default.
-		--]]
-		--[[ Override: frame:GetContextualPingType()
-		Used to define which contextual ping is used for the frame.
-
-		By default this wraps `C_Ping.GetContextualPingTypeForUnit(UnitGUID(frame.unit))`.
-		--]]
-		object:SetAttribute('ping-receiver', true)
 		Mixin(object, PingableType_UnitFrameMixin)
 
 		-- Make Clique kinda happy
@@ -605,6 +606,8 @@ do
 				frame:SetAttribute('*type1', 'target')
 				frame:SetAttribute('*type2', 'togglemenu')
 				frame:SetAttribute('oUF-guessUnit', unit)
+
+				frame:SetAttribute('ping-receiver', true)
 			end
 
 			local body = header:GetAttribute('oUF-initialConfigFunction')


### PR DESCRIPTION
When header children spawn during combat (e.g. a raid member joins) it would throw an error because we can't set attributes then.

Moving the attribute setter into a non-header block plus `initialConfigFunction` solves this, while we gotta keep the Mixin call where it was as the Mixin function nor the arg we pass through it exists in a secure environment.

Ref https://github.com/oUF-wow/oUF/pull/659#discussion_r1375492483