### PR TITLE
colors: Update color fetching

### DIFF
--- a/colors.lua
+++ b/colors.lua
@@ -144,7 +144,13 @@ local staggerIndices = {
 
 for power, color in next, PowerBarColor do
 	if (type(power) == 'string') then
-		if(type(select(2, next(color))) == 'table') then
+		if(color.r) then
+			colors.power[power] = oUF:CreateColor(color.r, color.g, color.b)
+
+			if(color.atlas) then
+				colors.power[power]:SetAtlas(color.atlas)
+			end
+		else
 			-- special handling for stagger
 			colors.power[power] = {}
 
@@ -152,13 +158,11 @@ for power, color in next, PowerBarColor do
 				local index = staggerIndices[name]
 				if(index) then
 					colors.power[power][index] = oUF:CreateColor(color_.r, color_.g, color_.b)
-				end
-			end
-		else
-			colors.power[power] = oUF:CreateColor(color.r, color.g, color.b)
 
-			if(color.atlas) then
-				colors.power[power]:SetAtlas(color.atlas)
+					if(color_.atlas) then
+						colors.power[power][index]:SetAtlas(color_.atlas)
+					end
+				end
 			end
 		end
 	end


### PR DESCRIPTION
In 10.2.5 the `predictionColor` subtable was added to most colours which broke our stagger detection. So instead of checking for subtables, it's easier to check if r/g/b entries are present.
Alternatively, it might be even better to check if a colour is `"STAGGER"` specifically, it's not like we'll be able to automagically catch a new colour if it has subtables as well because it might have differently named subtables.