### PR TITLE
tags: Fix threatcolor tag

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -468,7 +468,7 @@ local tagStrings = {
 	end]],
 
 	['threatcolor'] = [[function(u)
-		return Hex(GetThreatStatusColor(UnitThreatSituation(u)))
+		return Hex(GetThreatStatusColor(UnitThreatSituation(u) or 0))
 	end]],
 }
 


### PR DESCRIPTION
`GetThreatStatusColor` no longer accepts `nil`. Before 10.2.6 it used to return the same colour data for `nil` and `0`, see [wiki](https://warcraft.wiki.gg/wiki/API_GetThreatStatusColor). It also no longer accepts `-1`, but we don't use that.

Fixes #673.