### PR TITLE
totems: Use 4 elements in the example

### DIFF
--- a/elements/totems.lua
+++ b/elements/totems.lua
@@ -23,7 +23,7 @@ OnEnter and OnLeave script handlers will be set to display a Tooltip if the `Tot
 ## Examples
 
     local Totems = {}
-    for index = 1, 5 do
+    for index = 1, 4 do
         -- Position and size of the totem indicator
         local Totem = CreateFrame('Button', nil, self)
         Totem:SetSize(40, 40)


### PR DESCRIPTION
In https://github.com/oUF-wow/oUF/commit/c08b0d7a954b20ea55883ebafdefe7ecc6c1ea8d the constant was replaced with `5`, even though it has always represented `4`.

Mentioned in #701.