### PR TITLE
colors: Load class colors on PEW

### DIFF
--- a/colors.lua
+++ b/colors.lua
@@ -120,9 +120,10 @@ if(not customClassColors()) then
 
 	local eventHandler = CreateFrame('Frame')
 	eventHandler:RegisterEvent('ADDON_LOADED')
+	eventHandler:RegisterEvent('PLAYER_ENTERING_WORLD')
 	eventHandler:SetScript('OnEvent', function(self)
 		if(customClassColors()) then
-			self:UnregisterEvent('ADDON_LOADED')
+			self:UnregisterAllEvents()
 			self:SetScript('OnEvent', nil)
 		end
 	end)


### PR DESCRIPTION
oUF expects a preceding addon to implement this (and hit the OnLoad clause), or a succeeding addon (and hit the ADDON_LOADED clause). If the addon embedding oUF implements CUSTOM_CLASS_COLORS this will never run since oUF is typically loaded as a library early (voiding the OnLoad clause), and then some unrelated addon is responsible for triggering ADDON_LOADED, which can fail in scenarios where the embedder is the only/last addon to load.

By adding PEW as a last-resort event we make sure this doesn't happen, but we lose the ability for addons implementing CUSTOM_CLASS_COLORS as load-on-demand (which I don't think exists anyways, and would be dumb considering how addons are expected to consume the callbacks).

Reported by Simpy from the ElvUI team.