### PR TITLE
core: Handle up to 10 boss frames

### DIFF
--- a/ouf.lua
+++ b/ouf.lua
@@ -243,12 +243,14 @@ local function updateRaid(self, event)
 	end
 end
 
--- boss6-8 exsist in some encounters, but unit event registration seems to be
+-- boss6-10 exsist in some encounters, but unit event registration seems to be
 -- completely broken for them, so instead we use OnUpdate to update them.
 local eventlessUnits = {
 	boss6 = true,
 	boss7 = true,
 	boss8 = true,
+	boss9 = true,
+	boss10 = true,
 }
 
 local function isEventlessUnit(unit)


### PR DESCRIPTION
10 boss frames seem to be a thing for a while. And I double checked if it's still necessary to do this, unit events are still not supported for `"boss6"` and beyond.