### PR TITLE
API updates for 11.2

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -54,7 +54,9 @@ read_globals = {
 	'C_IncomingSummon',
 	'C_NamePlate',
 	'C_PvP',
+	'C_SpecializationInfo',
 	'C_Spell',
+	'C_SpellBook',
 	'C_UnitAuras',
 
 	-- API
@@ -67,7 +69,6 @@ read_globals = {
 	'GetRaidTargetIndex',
 	'GetReadyCheckStatus',
 	'GetRuneCooldown',
-	'GetSpecialization',
 	'GetSpecializationInfoByID',
 	'GetSpellPowerCost',
 	'GetTexCoordsForRoleSmallCircle',
@@ -85,7 +86,6 @@ read_globals = {
 	'InCombatLockdown',
 	'IsInInstance',
 	'IsLoggedIn',
-	'IsPlayerSpell',
 	'IsResting',
 	'PartyUtil',
 	'PlayerVehicleHasComboPoints',

--- a/elements/classpower.lua
+++ b/elements/classpower.lua
@@ -127,7 +127,7 @@ local function Update(self, event, unit, powerType)
 		cur = mod == 0 and 0 or cur / mod
 
 		-- BUG: Destruction is supposed to show partial soulshards, but Affliction and Demonology should only show full ones
-		if(ClassPowerType == 'SOUL_SHARDS' and GetSpecialization() ~= SPEC_WARLOCK_DESTRUCTION) then
+		if(ClassPowerType == 'SOUL_SHARDS' and C_SpecializationInfo.GetSpecialization() ~= SPEC_WARLOCK_DESTRUCTION) then
 			cur = cur - cur % 1
 		end
 
@@ -189,10 +189,10 @@ local function Visibility(self, event, unit)
 		shouldEnable = PlayerVehicleHasComboPoints()
 		unit = 'vehicle'
 	elseif(ClassPowerID) then
-		if(not RequireSpec or RequireSpec == GetSpecialization()) then
+		if(not RequireSpec or RequireSpec == C_SpecializationInfo.GetSpecialization()) then
 			-- use 'player' instead of unit because 'SPELLS_CHANGED' is a unitless event
 			if(not RequirePower or RequirePower == UnitPowerType('player')) then
-				if(not RequireSpell or IsPlayerSpell(RequireSpell)) then
+				if(not RequireSpell or C_SpellBook.IsSpellKnown(RequireSpell)) then
 					self:UnregisterEvent('SPELLS_CHANGED', Visibility)
 					shouldEnable = true
 					unit = 'player'

--- a/elements/runes.lua
+++ b/elements/runes.lua
@@ -18,7 +18,7 @@ A default texture will be applied if the sub-widgets are StatusBars and don't ha
 ## Options
 
 .colorSpec - Use `self.colors.runes[specID]` to color the bar based on player's spec. `specID` is defined by the return
-             value of [GetSpecialization](https://warcraft.wiki.gg/wiki/API_GetSpecialization) (boolean)
+             value of [C_SpecializationInfo.GetSpecialization](https://warcraft.wiki.gg/wiki/API_C_SpecializationInfo.GetSpecialization) (boolean)
 .sortOrder - Sorting order. Sorts by the remaining cooldown time, 'asc' - from the least cooldown time remaining (fully
              charged) to the most (fully depleted), 'desc' - the opposite (string?)['asc', 'desc']
 
@@ -83,7 +83,7 @@ end
 local function UpdateColor(self, event)
 	local element = self.Runes
 
-	local spec = GetSpecialization() or 0
+	local spec = C_SpecializationInfo.GetSpecialization() or 0
 
 	local color
 	if(spec > 0 and spec < 4 and element.colorSpec) then

--- a/elements/stagger.lua
+++ b/elements/stagger.lua
@@ -148,7 +148,7 @@ local function Path(self, ...)
 end
 
 local function Visibility(self, event, unit)
-	if(SPEC_MONK_BREWMASTER ~= GetSpecialization() or UnitHasVehiclePlayerFrameUI('player')) then
+	if(SPEC_MONK_BREWMASTER ~= C_SpecializationInfo.GetSpecialization() or UnitHasVehiclePlayerFrameUI('player')) then
 		if(self.Stagger:IsShown()) then
 			self.Stagger:Hide()
 			self:UnregisterEvent('UNIT_AURA', Path)

--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -139,7 +139,7 @@ local tagStrings = {
 	end]],
 
 	['arcanecharges'] = [[function()
-		if(GetSpecialization() == SPEC_MAGE_ARCANE) then
+		if(C_SpecializationInfo.GetSpecialization() == SPEC_MAGE_ARCANE) then
 			local num = UnitPower('player', Enum.PowerType.ArcaneCharges)
 			if(num > 0) then
 				return num
@@ -159,7 +159,7 @@ local tagStrings = {
 	end]],
 
 	['chi'] = [[function()
-		if(GetSpecialization() == SPEC_MONK_WINDWALKER) then
+		if(C_SpecializationInfo.GetSpecialization() == SPEC_MONK_WINDWALKER) then
 			local num = UnitPower('player', Enum.PowerType.Chi)
 			if(num > 0) then
 				return num
@@ -237,7 +237,7 @@ local tagStrings = {
 	end]],
 
 	['holypower'] = [[function()
-		if(GetSpecialization() == SPEC_PALADIN_RETRIBUTION) then
+		if(C_SpecializationInfo.GetSpecialization() == SPEC_PALADIN_RETRIBUTION) then
 			local num = UnitPower('player', Enum.PowerType.HolyPower)
 			if(num > 0) then
 				return num


### PR DESCRIPTION
Updated all deprecated APIs I could find, and no, `GetSpecializationInfoByID` wasn't namespaced unlike the rest.