### PR TITLE
castbar: Fix holdTime being ignored on nameplates

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -226,8 +226,11 @@ local function CastStart(self, event, unit)
 	end
 
 	if(not name or (isTradeSkill and element.hideTradeSkills)) then
-		resetAttributes(element)
-		element:Hide()
+		-- don't cancel hold time when we swap targets
+		if not (element.holdTime and element.holdTime > 0) then
+			resetAttributes(element)
+			element:Hide()
+		end
 
 		return
 	end
@@ -536,6 +539,7 @@ local function Update(...)
 end
 
 local function ForceUpdate(element)
+	print('forceupdate', element.__owner.unit)
 	return Update(element.__owner, 'ForceUpdate', element.__owner.unit)
 end
 


### PR DESCRIPTION
1. nameplate casts something (this is specific to nameplates only)
2. someone interrupts
3. player targets the nameplate while holdtime is active
    - this triggers UAE: https://github.com/oUF-wow/oUF/blob/1145ff11fc50a223689869873e6691bf39a90cc1/ouf.lua#L814
4. this triggers the castbar default update callback
    - https://github.com/oUF-wow/oUF/blob/1145ff11fc50a223689869873e6691bf39a90cc1/elements/castbar.lua#L535
5. since the unit isn't casting anything the behavior is to hide the castbar
    - https://github.com/oUF-wow/oUF/blob/1145ff11fc50a223689869873e6691bf39a90cc1/elements/castbar.lua#L230

This fix _might_ not be sufficient (my testing says so, but need a bigger sample).