### PR TITLE
blizzard: Do not reparent frames while in combat

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -21,9 +21,25 @@ local function insecureHide(self)
 	self:Hide()
 end
 
+local looseFrames = {}
+
+local watcher = CreateFrame('Frame')
+watcher:RegisterEvent('PLAYER_REGEN_ENABLED')
+watcher:SetScript('OnEvent', function()
+	for frame in next, looseFrames do
+		frame:SetParent(hiddenParent)
+	end
+
+	table.wipe(looseFrames)
+end)
+
 local function resetParent(self, parent)
 	if(parent ~= hiddenParent) then
-		self:SetParent(hiddenParent)
+		if(InCombatLockdown() and self:IsProtected()) then
+			looseFrames[self] = true
+		else
+			self:SetParent(hiddenParent)
+		end
 	end
 end
 


### PR DESCRIPTION
Just remembered about this bug, wanted to fix it for quite a while, it's unrelated to midnight, so it's in a separate PR.

```d
2x [ADDON_ACTION_BLOCKED] AddOn 'ls_UI' tried to call the protected function 'UNKNOWN()'.
[!BugGrabber/BugGrabber.lua]:583: in function '?'
[!BugGrabber/BugGrabber.lua]:507: in function <!BugGrabber/BugGrabber.lua:507>
[C]: ?
[C]: ?
[C]: in function 'SetParent'
[ls_UI/embeds/oUF/blizzard.lua]:26: in function <ls_UI/embeds/oUF/blizzard.lua:24>
[C]: in function 'SetParent'
```