### PR TITLE
castbar: Temporary fix bug with event payload

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -185,6 +185,13 @@ local function ShouldShow(element, unit)
 	return element.__owner.unit == unit
 end
 
+local BROKEN_EMPOWER_SPELLS = {
+	[382614] = true, -- Dream Breath
+	[355936] = true, -- Dream Breath
+	[355941] = true, -- Dream Breath
+	[376788] = true, -- Dream Breath
+}
+
 local function CastStart(self, event, unit)
 	local element = self.Castbar
 	if(not (element.ShouldShow or ShouldShow) (element, unit)) then
@@ -200,7 +207,7 @@ local function CastStart(self, event, unit)
 		local isEmpowered
 		name, text, texture, startTime, endTime, isTradeSkill, notInterruptible, spellID, isEmpowered, _, castID = UnitChannelInfo(unit)
 
-		if(event == 'UNIT_SPELLCAST_EMPOWER_START' and castID == 382614) then
+		if(event == 'UNIT_SPELLCAST_EMPOWER_START' and BROKEN_EMPOWER_SPELLS[castID]) then
 			-- BUG: Dream Breath triggers this event twice with castID and spellID swapped
 			return
 		end


### PR DESCRIPTION
ElvUI team reported something fishy going on with the event payload when casting [Dream Breath](https://www.wowhead.com/spell=355936/dream-breath), where the `UNIT_SPELLCAST_EMPOWER_START` fires twice, the first one containing swapped `spellID` and `castbarID` arg positions (without preserving secret aspect on the values), as present in this screenshot:

<img width="515" height="54" alt="image" src="https://github.com/user-attachments/assets/7ee789d1-42fd-4749-a208-0cb4caf9474f" />

This PR fixes that for oUF.

Blizzard is aware and will be looking into a fix.