### PR TITLE
Remove unsupported TOC Interface version

### DIFF
--- a/oUF.toc
+++ b/oUF.toc
@@ -1,4 +1,4 @@
-## Interface: 110207, 120000, 120001
+## Interface: 120000, 120001
 ## Title: oUF
 ## Author: Haste, lightspark, p3lim, Rainrider
 ## Version: @project-version@


### PR DESCRIPTION
The bot will fix this anyways come wednesday, but I want it in the 13.0.1 release before then.