### PR TITLE
health: Fix example using TempLoss

### DIFF
--- a/elements/health.lua
+++ b/elements/health.lua
@@ -65,6 +65,7 @@ The following options are listed by priority. The first check that returns true 
 
     -- Alternatively, if .TempLoss is being used
     local TempLoss = CreateFrame('StatusBar', nil, self)
+    TempLoss:SetStatusBarTexture('UI-HUD-UnitFrame-Target-PortraitOn-Bar-TempHPLoss')
     TempLoss:SetReverseFill(true)
     TempLoss:SetHeight(20)
     TempLoss:SetPoint('TOP')


### PR DESCRIPTION
Without a texture set on the TempLoss widget the Health element won't have anywhere to anchor to, resulting in errors.

Fixes #755