### PR TITLE
meta: Release on GitHub too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: write # required to create a github release
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -30,6 +33,7 @@ jobs:
 
       - name: Package and release
         uses: BigWigsMods/packager@v2
-    env:
-      CF_API_KEY: ${{ secrets.CF_API_KEY }}
-      WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
While this allows some addon managers to pull from GitHub, it also allows people to subscribe to releases on the repository and get notifications in emails, or through RSS feeds.