### PR TITLE
blizzard: Don't disable the default class power bar

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -105,11 +105,6 @@ local function handleFrame(baseName, doNotReparent, isNamePlate)
 			totFrame:UnregisterAllEvents()
 		end
 
-		local classPowerBar = frame.classPowerBar
-		if(classPowerBar) then
-			classPowerBar:UnregisterAllEvents()
-		end
-
 		local ccRemoverFrame = frame.CcRemoverFrame
 		if(ccRemoverFrame) then
 			ccRemoverFrame:UnregisterAllEvents()


### PR DESCRIPTION
It's not really owned by the PlayerFrame, it's owned by a manager container, and if we disable events on it here it'll break the class power bar for the personal resource display.

Since the default is anchored to the PlayerFrame, which we hide, it shouldn't have any ill effects other than wasting events, but that's a minor thing.

Fixes #779