### PR TITLE
Restrict [class] tag to players only

### DIFF
--- a/elements/tags.lua
+++ b/elements/tags.lua
@@ -444,7 +444,11 @@ local tagFuncs = setmetatable(
 		curpp = UnitPower,
 		maxhp = UnitHealthMax,
 		maxpp = UnitPowerMax,
-		class = UnitClass,
+		class = function(unit)
+			if UnitIsPlayer(unit) then
+				return UnitClass(unit)
+			end
+		end,
 		faction = UnitFactionGroup,
 		race = UnitRace,
 	},


### PR DESCRIPTION
[class] currently maps directly to UnitClass, which causes NPCs to return their name as the class value.

This results in [class] showing NPC names when targeting non-player units.

This change restricts the tag to UnitIsPlayer(unit), so it only returns class information for player units and returns nil for normal NPCs.
