### PR TITLE
readycheckindicator: Use atlases

### DIFF
--- a/elements/readycheckindicator.lua
+++ b/elements/readycheckindicator.lua
@@ -17,9 +17,7 @@ Default textures will be applied if the layout does not provide custom ones. See
 .finishedTime    - For how many seconds the icon should stick after a check has completed. Defaults to 10 (number).
 .fadeTime        - For how many seconds the icon should fade away after the stick duration has completed. Defaults to
                    1.5 (number).
-.readyTexture    - Path to an alternate texture for the ready check 'ready' status.
-.notReadyTexture - Path to an alternate texture for the ready check 'notready' status.
-.waitingTexture  - Path to an alternate texture for the ready check 'waiting' status.
+.useAtlasSize    - Makes the element use preprogrammed atlas' size instead of its set dimensions (boolean)
 
 ## Attributes
 
@@ -41,11 +39,6 @@ local oUF = ns.oUF
 local Private = oUF.Private
 
 local unitExists = Private.unitExists
-
--- TODO: Replace with atlases in the next major
-local READY_CHECK_READY_TEXTURE = "Interface\\RaidFrame\\ReadyCheck-Ready"
-local READY_CHECK_NOT_READY_TEXTURE = "Interface\\RaidFrame\\ReadyCheck-NotReady"
-local READY_CHECK_WAITING_TEXTURE = "Interface\\RaidFrame\\ReadyCheck-Waiting"
 
 local function OnFinished(self)
 	local element = self:GetParent()
@@ -77,11 +70,23 @@ local function Update(self, event)
 	local status = GetReadyCheckStatus(unit)
 	if(unitExists(unit) and status) then
 		if(status == 'ready') then
-			element:SetTexture(element.readyTexture)
+			if(element.readyTexture) then
+				element:SetTexture(element.readyTexture) -- DEPRECATED
+			else
+				element:SetAtlas('UI-LFG-ReadyMark-Raid', element.useAtlasSize)
+			end
 		elseif(status == 'notready') then
-			element:SetTexture(element.notReadyTexture)
+			if(element.notReadyTexture) then
+				element:SetTexture(element.notReadyTexture) -- DEPRECATED
+			else
+				element:SetAtlas('UI-LFG-DeclineMark-Raid', element.useAtlasSize)
+			end
 		else
-			element:SetTexture(element.waitingTexture)
+			if(element.waitingTexture) then
+				element:SetTexture(element.waitingTexture) -- DEPRECATED
+			else
+				element:SetAtlas('UI-LFG-PendingMark-Raid', element.useAtlasSize)
+			end
 		end
 
 		element.status = status
@@ -93,7 +98,11 @@ local function Update(self, event)
 
 	if(event == 'READY_CHECK_FINISHED') then
 		if(element.status == 'waiting') then
-			element:SetTexture(element.notReadyTexture)
+			if(element.notReadyTexture) then
+				element:SetTexture(element.notReadyTexture) -- DEPRECATED
+			else
+				element:SetAtlas('UI-LFG-DeclineMark-Raid', element.useAtlasSize)
+			end
 		end
 
 		element.Animation:Play()
@@ -131,10 +140,6 @@ local function Enable(self, unit)
 	if(element and (unit == 'party' or unit == 'raid')) then
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
-
-		element.readyTexture = element.readyTexture or READY_CHECK_READY_TEXTURE
-		element.notReadyTexture = element.notReadyTexture or READY_CHECK_NOT_READY_TEXTURE
-		element.waitingTexture = element.waitingTexture or READY_CHECK_WAITING_TEXTURE
 
 		local AnimationGroup = element:CreateAnimationGroup()
 		AnimationGroup:HookScript('OnFinished', OnFinished)


### PR DESCRIPTION
Keep using textures if layout actually defined them, but mark that use as deprecated and remove it in v14.