### PR TITLE
health: Fix typo

### DIFF
--- a/elements/health.lua
+++ b/elements/health.lua
@@ -174,7 +174,7 @@ local function UpdateColor(self, event, unit)
 	elseif(element.colorReaction and UnitReaction(unit, 'player')) then
 		color = self.colors.reaction[UnitReaction(unit, 'player')]
 	elseif(element.colorSmooth and self.colors.health:GetCurve()) then
-		color = self.values:EvaluateCurrentHealthPercent(self.colors.health:GetCurve())
+		color = element.values:EvaluateCurrentHealthPercent(self.colors.health:GetCurve())
 	elseif(element.colorHealth) then
 		color = self.colors.health
 	end


### PR DESCRIPTION
I believe `element` is what's supposed to be referenced here not `self` (frame) 