### PR TITLE
castbar: handle nil in UpdatePips

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -109,6 +109,7 @@ local function CreatePip(element)
 end
 
 local function UpdatePips(element, stages)
+	stages = stages or {}
 	local isHoriz = element:GetOrientation() == 'HORIZONTAL'
 	local elementSize = isHoriz and element:GetWidth() or element:GetHeight()
 


### PR DESCRIPTION
The Blizzard docs suggest this should never be nil, but I managed to get a lua error implying it was anyway. Handle this safely by replacing nil with an empty table.