### PR TITLE
core: Use new rolesets

### DIFF
--- a/blizzard.lua
+++ b/blizzard.lua
@@ -7,37 +7,11 @@ local MAX_BOSS_FRAMES = _G.MAX_BOSS_FRAMES or 5
 -- sourced from Blizzard_FrameXMLBase/Shared/Constants.lua
 local MEMBERS_PER_RAID_GROUP = _G.MEMBERS_PER_RAID_GROUP or 5
 
-local hookedFrames = {}
 local isArenaHooked = false
 local isBossHooked = false
 local isPartyHooked = false
 
-local hiddenParent = CreateFrame('Frame', nil, UIParent)
-hiddenParent:SetAllPoints()
-hiddenParent:Hide()
-
-local looseFrames = {}
-local watcher = CreateFrame('Frame')
-watcher:RegisterEvent('PLAYER_REGEN_ENABLED')
-watcher:SetScript('OnEvent', function()
-	for frame in next, looseFrames do
-		frame:SetParent(hiddenParent)
-	end
-
-	table.wipe(looseFrames)
-end)
-
-local function resetParent(self, parent)
-	if(parent ~= hiddenParent) then
-		if(InCombatLockdown() and self:IsProtected()) then
-			looseFrames[self] = true
-		else
-			self:SetParent(hiddenParent)
-		end
-	end
-end
-
-local function handleFrame(baseName, doNotReparent)
+local function handleFrame(baseName)
 	local frame
 	if(type(baseName) == 'string') then
 		frame = _G[baseName]
@@ -47,17 +21,7 @@ local function handleFrame(baseName, doNotReparent)
 
 	if(frame) then
 		frame:UnregisterAllEvents()
-		frame:Hide()
-
-		if(not doNotReparent) then
-			frame:SetParent(hiddenParent)
-
-			if(not hookedFrames[frame]) then
-				hooksecurefunc(frame, 'SetParent', resetParent)
-
-				hookedFrames[frame] = true
-			end
-		end
+		frame:SetRolesets('alwaysBlocked')
 
 		local health = frame.healthBar or frame.healthbar or frame.HealthBar or (frame.HealthBarsContainer and frame.HealthBarsContainer.healthBar)
 		if(health) then
@@ -128,12 +92,8 @@ function oUF:DisableBlizzard(unit)
 			-- future, watch it
 			handleFrame(BossTargetFrameContainer)
 
-			-- do not reparent frames controlled by containers, the vert/horiz
-			-- layout code will go insane because it won't be able to calculate
-			-- the size properly, 0 or negative sizes in turn will break the
-			-- layout manager, fun...
 			for i = 1, MAX_BOSS_FRAMES do
-				handleFrame('Boss' .. i .. 'TargetFrame', true)
+				handleFrame('Boss' .. i .. 'TargetFrame')
 			end
 		end
 	elseif(unit:match('party%d?$')) then
@@ -143,7 +103,7 @@ function oUF:DisableBlizzard(unit)
 			handleFrame(PartyFrame)
 
 			for frame in PartyFrame.PartyMemberFramePool:EnumerateActive() do
-				handleFrame(frame, true)
+				handleFrame(frame)
 			end
 
 			for i = 1, MEMBERS_PER_RAID_GROUP do
@@ -157,18 +117,18 @@ function oUF:DisableBlizzard(unit)
 			handleFrame(CompactArenaFrame)
 
 			for _, frame in next, CompactArenaFrame.memberUnitFrames do
-				handleFrame(frame, true)
+				handleFrame(frame)
 			end
 
 			-- old arena frames, they're still used for flag carriers etc in battlegrounds
 			handleFrame(ArenaEnemyMatchFramesContainer)
 
 			for _, frame in next, ArenaEnemyMatchFramesContainer.UnitFrames do
-				handleFrame(frame, true)
+				handleFrame(frame)
 			end
 		end
 	elseif(unit:match('nameplate%d?%d?%d?$')) then
 		local frame = C_NamePlate.GetNamePlateForUnit(unit)
-		handleFrame(frame.UnitFrame, true)
+		handleFrame(frame.UnitFrame)
 	end
 end

--- a/ouf.lua
+++ b/ouf.lua
@@ -19,11 +19,6 @@ local callback, objects, headers = {}, {}, {}
 local elements = {}
 local activeElements = {}
 
-local PetBattleFrameHider = CreateFrame('Frame', (global or parent) .. '_PetBattleFrameHider', UIParent, 'SecureHandlerStateTemplate')
-PetBattleFrameHider:SetAllPoints()
-PetBattleFrameHider:SetFrameStrata('LOW')
-RegisterStateDriver(PetBattleFrameHider, 'visibility', '[petbattle] hide; show')
-
 local function updateActiveUnit(self, event)
 	-- Calculate units to work with
 	local realUnit, modUnit = SecureButton_GetUnit(self), SecureButton_GetModifiedUnit(self)
@@ -644,7 +639,8 @@ do
 
 		local isPetHeader = template:match('PetHeader')
 		local name = overrideName or generateName(nil, ...)
-		local header = Mixin(CreateFrame('Frame', name, PetBattleFrameHider, template), headerMixin)
+		local header = Mixin(CreateFrame('Frame', name, UIParent, template), headerMixin)
+		header:SetRolesets('unitFrames')
 
 		header:SetAttribute('template', 'SecureUnitButtonTemplate, SecureHandlerStateTemplate, SecureHandlerEnterLeaveTemplate, PingableUnitFrameTemplate')
 
@@ -733,8 +729,14 @@ function oUF:Spawn(unit, overrideName)
 	unit = unit:lower()
 
 	local name = overrideName or generateName(unit)
-	local object = CreateFrame('Button', name, PetBattleFrameHider, 'SecureUnitButtonTemplate, PingableUnitFrameTemplate')
+	local object = CreateFrame('Button', name, UIParent, 'SecureUnitButtonTemplate, PingableUnitFrameTemplate')
 	Private.UpdateUnits(object, unit)
+
+	if(unit:match('arena%d?')) then
+		object:SetRolesets('arenaFrames')
+	else
+		object:SetRolesets('unitFrames')
+	end
 
 	self:DisableBlizzard(unit)
 	walkObject(object, unit)


### PR DESCRIPTION
These are used to conditionally show/hide certain parts of the UI when other UI elements ask for it (i.e. hide unit frames during pet battle), which means we no longer need a separate parent to deal with this.

CUF and others already use it, so if this works as expected we should too.

See [Blizzard_UIModes](https://github.com/BigWigsMods/WoWUI/tree/ptr/AddOns/Blizzard_UIModes) and the [Roleset API](https://github.com/BigWigsMods/WoWUI/blob/ptr/AddOns/Blizzard_APIDocumentationGenerated/RolesetSystemDocumentation.lua)