### PR TITLE
castbar: Reset before we start a cast

### DIFF
--- a/elements/castbar.lua
+++ b/elements/castbar.lua
@@ -191,6 +191,9 @@ local function CastStart(self, event, unit)
 		return
 	end
 
+	-- reset first to avoid any attributes that might be stuck
+	resetAttributes(element)
+
 	local direction, duration = Enum.StatusBarTimerDirection.ElapsedTime
 	local name, text, texture, startTime, endTime, isTradeSkill, _, notInterruptible, spellID, castID = UnitCastingInfo(unit)
 	if(name) then


### PR DESCRIPTION
Unsure what could cause this, maybe a layout messed around with the castbar attributes after it was reset, so we'll just do this to be safe.

Should fix #863