### PR TITLE
auras: Rewrite for 12.1

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,6 +21,7 @@ read_globals = {
 
 	-- FrameXML
 	'AnchorUtil',
+	'AuraUtil',
 	'ArenaEnemyMatchFramesContainer',
 	'AuraContainerSortDirection',
 	'AuraContainerSortMethod',

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -17,10 +17,13 @@ ignore = {
 
 read_globals = {
 	string = {fields = {'join', 'split', 'trim'}},
-	table = {fields = {'removemulti', 'wipe'}},
+	table = {fields = {'count', 'removemulti', 'wipe'}},
 
 	-- FrameXML
+	'AnchorUtil',
 	'ArenaEnemyMatchFramesContainer',
+	'AuraContainerSortDirection',
+	'AuraContainerSortMethod',
 	'BossTargetFrameContainer',
 	'Clamp',
 	'ColorMixin',
@@ -28,6 +31,7 @@ read_globals = {
 	'CompactArenaFrame',
 	'Constants',
 	'CreateColor',
+	'CustomAuraContainerAuraProcessingPolicy',
 	'Enum',
 	'FocusFrame',
 	'GameTooltip',

--- a/colors.lua
+++ b/colors.lua
@@ -145,14 +145,10 @@ if(not customClassColors()) then
 	end)
 end
 
--- copy of DEBUFF_DISPLAY_INFO from AuraUtil
-colors.dispel[oUF.Enum.DispelType.None] = _G.DEBUFF_TYPE_NONE_COLOR
-colors.dispel[oUF.Enum.DispelType.Magic] = _G.DEBUFF_TYPE_MAGIC_COLOR
-colors.dispel[oUF.Enum.DispelType.Curse] = _G.DEBUFF_TYPE_CURSE_COLOR
-colors.dispel[oUF.Enum.DispelType.Disease] = _G.DEBUFF_TYPE_DISEASE_COLOR
-colors.dispel[oUF.Enum.DispelType.Poison] = _G.DEBUFF_TYPE_POISON_COLOR
-colors.dispel[oUF.Enum.DispelType.Bleed] = _G.DEBUFF_TYPE_BLEED_COLOR
-colors.dispel[oUF.Enum.DispelType.Enrage] = oUF:CreateColor(243, 95, 245)
+for dispelName, dispelInfo in next, AuraUtil.GetDebuffDisplayInfoTable() do
+	colors.dispel[dispelName] = oUF:CreateColor(dispelInfo.color:GetRGB())
+end
+colors.dispel.Enrage = oUF:CreateColor(243, 95, 245) -- no default color by Blizzard
 
 for eclass, color in next, _G.FACTION_BAR_COLORS do
 	colors.reaction[eclass] = oUF:CreateColor(color.r, color.g, color.b)

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -1,8 +1,8 @@
 --[[
 # Element: Auras
 
-Handles creation of [aura containers](https://warcraft.wiki.gg/wiki/UIOBJECT_AuraContainer), groups,
-slots, and [buttons](https://warcraft.wiki.gg/wiki/UIOBJECT_AuraButton).
+Handles creation of [aura containers](https://warcraft.wiki.gg/wiki/INTRINSIC_AuraContainer), groups,
+slots, and [buttons](https://warcraft.wiki.gg/wiki/INTRINSIC_AuraButton).
 
 ## Notes
 
@@ -209,8 +209,8 @@ local elementMixin = {}
 Defines a group of auras to display on the element.  
 This can be defined multiple times.
 
-* filter  - aura filter for this group ([AuraFilter](https://warcraft.wiki.gg/wiki/API_type/AuraFilters))
-* options - options for this group (TODO: link to wiki)
+* filter  - aura filter for this group ([AuraFilter](https://warcraft.wiki.gg/wiki/API_types/AuraFilters))
+* options - options for this group ([CustomAuraContainerGroupDefaultOptions](https://warcraft.wiki.gg/wiki/FrameXML_types/CustomAuraContainerGroupDefaultOptions))
 
 ## Notes
 
@@ -279,8 +279,8 @@ Defines a slot for a single buff or debuff to create from the element.
 The slot can be manually positioned if necessary.  
 This can be defined multiple times.
 
-* filter  - aura filter for this group ([AuraFilter](https://warcraft.wiki.gg/wiki/API_type/AuraFilters))
-* options - options for this group (TODO: link to wiki)
+* filter  - aura filter for this group ([AuraFilter](https://warcraft.wiki.gg/wiki/API_types/AuraFilters))
+* options - options for this group ([CustomAuraContainerSlotDefaultOptions](https://warcraft.wiki.gg/wiki/FrameXML_types/CustomAuraContainerSlotDefaultOptions))
 
 ## Notes
 
@@ -349,7 +349,7 @@ methods on the element.
 .paddingRight  - Padding on the right side of the element. Takes priority over `padding` (number?)
 .paddingTop    - Padding on the top side of the element. Takes priority over `padding` (number?)
 .paddingBottom - Padding on the bottom side of the element. Takes priority over `padding` (number?)
-.policy        - Policy for how auras should be processed. See CustomAuraContainerProcessAuraPolicyDefaultOptions (table?)
+.policy        - Policy for how auras should be processed. See [CustomAuraContainerProcessAuraPolicyDefaultOptions](https://warcraft.wiki.gg/wiki/FrameXML_types/CustomAuraContainerProcessAuraPolicyDefaultOptions) (table?)
 .templates     - Extra templates to use for the aura element (string?)
 
 ## Returns

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -1,924 +1,432 @@
 --[[
 # Element: Auras
 
-Handles creation and updating of aura buttons.
-
-## Widget
-
-Auras   - A Frame to hold `Button`s representing both buffs and debuffs.
-Buffs   - A Frame to hold `Button`s representing buffs.
-Debuffs - A Frame to hold `Button`s representing debuffs.
+Handles creation of [aura containers](https://warcraft.wiki.gg/wiki/UIOBJECT_AuraContainer), groups,
+slots, and [buttons](https://warcraft.wiki.gg/wiki/UIOBJECT_AuraButton).
 
 ## Notes
 
-At least one of the above widgets must be present for the element to work.
+This is not a traditional element; similar to Tags it only exposes meta functions.
 
-## Options
+The options detailed below are attributes on the element returned from the meta function, see each
+method documented further down for additional options. These options are shared across all buttons,
+groups and slots for each element.
 
-.disableMouse             - Disables mouse events (boolean)
-.disableCooldown          - Disables the cooldown spiral (boolean)
-.size                     - Aura button size. Defaults to 16 (number)
-.width                    - Aura button width. Takes priority over `size` (number)
-.height                   - Aura button height. Takes priority over `size` (number)
-.onlyShowPlayer           - Shows only auras created by player/vehicle (boolean)
-.showStealableBuffs       - Displays the stealable texture on buffs that can be stolen (boolean)
-.spacing                  - Spacing between each button. Defaults to 0 (number)
-.spacingX                 - Horizontal spacing between each button. Takes priority over `spacing` (number)
-.spacingY                 - Vertical spacing between each button. Takes priority over `spacing` (number)
-.growthX                  - Horizontal growth direction. Defaults to 'RIGHT' (string)
-.growthY                  - Vertical growth direction. Defaults to 'UP' (string)
-.initialAnchor            - Anchor point for the aura buttons. Defaults to 'BOTTOMLEFT' (string)
-.filter                   - Custom filter list for auras to display. Defaults to 'HELPFUL' for buffs and 'HARMFUL' for
-                            debuffs (string)
-.tooltipAnchor            - Anchor point for the tooltip. Defaults to 'ANCHOR_BOTTOMRIGHT', however, if a frame has
-                            anchoring restrictions it will be set to 'ANCHOR_CURSOR' (string)
-.reanchorIfVisibleChanged - Reanchors aura buttons when the number of visible auras has changed (boolean)
-.showType                 - Show Overlay texture colored by oUF.colors.dispel (boolean)
-.showDebuffType           - Show Overlay texture colored by oUF.colors.dispel when it's a debuff. Exclusive with .showType (boolean)
-.showBuffType             - Show Overlay texture colored by oUF.colors.dispel when it's a buff. Exclusive with .showType (boolean)
-.minCount                 - Minimum number of aura applications for the Count text to be visible. Defaults to 2 (number)
-.maxCount                 - Maximum number of aura applications for the Count text, anything above renders "*". Defaults to 999 (number)
-.maxCols                  - Maximum number of aura button columns before wrapping to a new row. Defaults to element width divided by aura button size (number)
+## Options (for buttons)
 
-## Options Auras
+> Note: these options can be set on either the element or within the options table for groups and slots
 
-.numBuffs     - The maximum number of buffs to display. Defaults to 32 (number)
-.numDebuffs   - The maximum number of debuffs to display. Defaults to 40 (number)
-.numTotal     - The maximum number of auras to display. Prioritizes buffs over debuffs. Defaults to the sum of
-                .numBuffs and .numDebuffs (number)
-.gap          - Controls the creation of an invisible button between buffs and debuffs. Defaults to false (boolean)
-.buffFilter   - Custom filter list for buffs to display. Takes priority over `filter` (string)
-.debuffFilter - Custom filter list for debuffs to display. Takes priority over `filter` (string)
+.size                   - Aura button size. Defaults to 16 (number?)
+.width                  - Aura button width. Takes priority over `size` (number?)
+.height                 - Aura button height. Takes priority over `size` (number?)
+.showBuffBorder         - Show dispel border texture when it's a buff (boolean?)
+.showDebuffBorder       - Show dispel border texture when it's a debuff (boolean?)
+.dispelBorderStyle      - Which style to use for the dispel border ([Enum.CustomAuraButtonDispelTypeTextureStyle](https://warcraft.wiki.gg/wiki/Enum.CustomAuraButtonDispelTypeTextureStyle)?)
+.showBuffIndicator      - Show dispel indicator texture when it's a buff (boolean?)
+.showDebuffIndicator    - Show dispel indicator texture when it's a debuff (boolean?)
+.showStealableBorder    - Show a border texture when it's a stealable buff (boolean?)
+.stealableBorderFilter  - Filter to use for the stealable border. Defaults to `Enum.CustomAuraButtonDispelTypeStealableFilter.Stealable` ([Enum.CustomAuraButtonDispelTypeTextureStyle](https://warcraft.wiki.gg/wiki/Enum.CustomAuraButtonDispelTypeStealableFilter)?)
+.showCount              - Show Count fontstring representing aura applications (boolean?)
+.countFormatter         - Formatter used to adjust the text displayed on the Count fontstring ([NumericFormatter](https://warcraft.wiki.gg/wiki/ScriptObject_NumericFormatter)?)
+.showDuration           - Show Duration fontstring representing time remaining of the aura (boolean?)
+.durationBinding        - Duration binding base object ([DurationTextBinding](https://warcraft.wiki.gg/wiki/ScriptObject_DurationTextBinding)?)
+.durationFormat         - Text format for the text displayed on the Duration fontstring. `durationFormat` takes presedence (string?)
+.durationFormatter      - Formatter used to adjust the text displayed on the Duration fontstring ([NumericFormatter](https://warcraft.wiki.gg/wiki/ScriptObject_NumericFormatter)?)
+.durationColors         - Curve used to color the text displayed on the Duration fontstring ([ColorCurve](https://warcraft.wiki.gg/wiki/ScriptObject_ColorCurveObject)?)
+.disableMouse           - Disables mouse events (boolean?)
+.disableCooldown        - Disables the provided cooldown spiral frame (boolean?)
+.cancelButton           - A list of mouse buttons and actions used to cancel the aura, if possible ([string](https://warcraft.wiki.gg/wiki/API_Button_RegisterForClicks)?)
+.tooltipAnchor          - Anchor point for the tooltip. Defaults to 'ANCHOR_BOTTOMLEFT' (string?)
+.tooltipOffsetX         - Horizontal anchor offset for the tooltip (number?)
+.tooltipOffsetY         - Vertical anchor offset for the tooltip (number?)
+.tooltipHideInCombat    - Whether to hide the tooltip during combat (boolean?)
 
-## Options Buffs
+## Options (for groups)
 
-.num - Number of buffs to display. Defaults to 32 (number)
+> Note: these are shared attributes for all groups of an element, and can be set within group options as well
 
-## Options Debuffs
-
-.num - Number of debuffs to display. Defaults to 40 (number)
-
-## Attributes
-
-.dispelColorCurve - Curve object with points defined for each index in oUF.colors.dispel
-
-## Button Attributes
-
-button.auraInstanceID - unique ID for the current aura being tracked by the button (number)
-button.isHarmfulAura  - indicates if the button holds a debuff (boolean)
+.maxFrameCount    - Number of buttons to display. Defaults to an infinite number (number)
+.elementSpacing   - Spacing between each button (number)
+.lineSpacing      - Spacing between each button row or column (number)
+.groupSpacing     - Spacing between each group (number)
+.groupLineSpacing - Spacing between each group row or column
+.forceNewLine     - Whether to force a new row or column between each group (boolean)
 
 ## Examples
 
-    -- Position and size
-    local Buffs = CreateFrame('Frame', nil, self)
-    Buffs:SetPoint('RIGHT', self, 'LEFT')
-    Buffs:SetSize(16 * 2, 16 * 16)
+  -- Initialize
+  local Auras = self:CreateAuras()
+  Auras.num = 10 -- per-group option
 
-    -- Register with oUF
-    self.Buffs = Buffs
+  -- Position and size
+  Auras:SetPoint('TOP', self, 'BOTTOM')
+
+  -- Enable some sub-widgets
+  Auras.showCount = true
+  Auras.showBuffBorder = true
+
+  -- Register a group using a filter and some options
+  Auras:AddGroup('HELPFUL', {
+    maxFrameCount = 20, -- overrides Auras.num
+    initializeFrame = PostCreateAuraButton, -- overrides CreateButton override
+    showDebuffBorder = true, -- group-specific option for its buttons
+  })
+
+  -- Register another group using a different filter and no options
+  Auras:AddGroup('HARMFUL')
+
+  -- Register a slot with a filter to only include Mark of the Wild
+  Auras:AddSlot('HELPFUL', {
+    candidateFilters = {
+      includeSpellIDs = {
+        [1126] = true,
+      }
+    }
+  })
+
 --]]
-
 local _, ns = ...
 local oUF = ns.oUF
 
-local function UpdateTooltip(self)
-	if(GameTooltip:IsForbidden()) then return end
+local Private = oUF.Private
+local argcheck = Private.argcheck
 
-	GameTooltip:SetUnitAuraByAuraInstanceID(self:GetParent().__owner.__unit, self.auraInstanceID)
-end
+local STATE = {}
 
-local function onEnter(self)
-	if(GameTooltip:IsForbidden() or not self:IsVisible()) then return end
+local function CreateButton(element, options, button)
+	local size = options.size or element.size or 16
+	local width = options.width or element.width or size
+	local height = options.height or element.height or size
+	button:SetSize(width, height)
+	button:EnableMouse(not (options.disableMouse or element.disableMouse))
 
-	-- Avoid parenting GameTooltip to frames with anchoring restrictions,
-	-- otherwise it'll inherit said restrictions which will cause issues with
-	-- its further positioning, clamping, etc
-	GameTooltip:SetOwner(self, self:GetParent().__restricted and 'ANCHOR_CURSOR' or self:GetParent().tooltipAnchor)
-	self:UpdateTooltip()
-end
+	local tooltipAnchor = options.tooltipAnchor or element.tooltipAnchor or 'ANCHOR_BOTTOMLEFT'
+	local tooltipOffsetX = options.tooltipOffsetX or element.tooltipOffsetX or 0
+	local tooltipOffsetY = options.tooltipOffsetY or element.tooltipOffsetY or 0
+	button:SetTooltipAnchorPoint(tooltipAnchor, tooltipOffsetX, tooltipOffsetY)
+	button:SetHideTooltipInCombat(options.tooltipHideInCombat or element.tooltipHideInCombat)
 
-local function onLeave()
-	if(GameTooltip:IsForbidden()) then return end
-
-	GameTooltip:Hide()
-end
-
-local function CreateButton(element, index)
-	local button = CreateFrame('Button', element:GetDebugName() .. 'Button' .. index, element)
-
-	local cd = CreateFrame('Cooldown', '$parentCooldown', button, 'CooldownFrameTemplate')
-	cd:SetAllPoints()
-	button.Cooldown = cd
+	if(not (options.disableCooldown or element.disableCooldown)) then
+		local cooldown = CreateFrame('Cooldown', '$parentCooldown', button, 'CooldownFrameTemplate')
+		cooldown:SetAllPoints()
+		button.Cooldown = cooldown
+		button:SetDurationCooldown(cooldown)
+	end
 
 	local icon = button:CreateTexture(nil, 'BORDER')
 	icon:SetAllPoints()
 	button.Icon = icon
+	button:SetIcon(icon)
 
-	local countFrame = CreateFrame('Frame', nil, button)
-	countFrame:SetAllPoints(button)
-	countFrame:SetFrameLevel(cd:GetFrameLevel() + 1)
+	local textParent
+	if((options.showCount or element.showCount) or (options.showDuration or element.showDuration)) then
+		if(options.disableCooldown or element.disableCooldown) then
+			textParent = button
+		else
+			-- raise frame level to render text above cooldown
+			textParent = CreateFrame('Frame', nil, button)
+			textParent:SetAllPoints()
+			textParent:SetFrameLevel(button.Cooldown:GetFrameLevel() + 1)
+		end
+	end
 
-	local count = countFrame:CreateFontString(nil, 'OVERLAY', 'NumberFontNormal')
-	count:SetPoint('BOTTOMRIGHT', countFrame, 'BOTTOMRIGHT', -1, 0)
-	button.Count = count
+	if(options.showCount or element.showCount) then
+		local count = textParent:CreateFontString(nil, 'OVERLAY', 'NumberFontNormal')
+		count:SetPoint('BOTTOMRIGHT', -1, 0)
+		button.Count = count
+		button:SetApplicationCount(count, {
+			formatter = options.countFormatter or element.countFormatter,
+		})
+	end
 
-	local overlay = button:CreateTexture(nil, 'OVERLAY')
-	overlay:SetTexture([[Interface\Buttons\UI-Debuff-Overlays]])
-	overlay:SetAllPoints()
-	overlay:SetTexCoord(0.296875, 0.5703125, 0, 0.515625)
-	button.Overlay = overlay
+	if((options.showBuffBorder or element.showBuffBorder) or (options.showDebuffBorder or element.showDebuffBorder)) then
+		local border = button:CreateTexture(nil, 'OVERLAY')
+		border:SetAllPoints()
+		button.Border = border
+		button:AddDispelTypeTexture(border, {
+			style = options.dispelBorderStyle or element.dispelBorderStyle or Enum.CustomAuraButtonDispelTypeTextureStyle.Border,
+			showWhenHarmful = options.showDebuffBorder or element.showDebuffBorder,
+			showWhenHelpful = options.showBuffBorder or element.showBuffBorder,
+			customDispelColorMap = element.__owner.colors.dispel,
+		})
+	end
 
-	local stealable = button:CreateTexture(nil, 'OVERLAY')
-	stealable:SetTexture([[Interface\TargetingFrame\UI-TargetingFrame-Stealable]])
-	stealable:SetPoint('TOPLEFT', -3, 3)
-	stealable:SetPoint('BOTTOMRIGHT', 3, -3)
-	stealable:SetBlendMode('ADD')
-	button.Stealable = stealable
+	if((options.showDebuffIndicator or element.showDebuffIndicator) or (options.showBuffIndicator or element.showBuffIndicator)) then
+		local dispelIndicator = button:CreateTexture(nil, 'OVERLAY', nil, 1) -- above other overlay widgets
+		dispelIndicator:SetPoint('CENTER', button, 'TOPRIGHT')
+		dispelIndicator:SetSize(18, 18)
+		button.DispelIndicator = dispelIndicator
+		button:AddDispelTypeTexture(dispelIndicator, {
+			style = Enum.CustomAuraButtonDispelTypeTextureStyle.Icon,
+			showWhenHarmful = options.showDebuffIndicator or element.showDebuffIndicator,
+			showWhenHelpful = options.showBuffIndicator or element.showBuffIndicator,
+		})
+	end
 
-	button.UpdateTooltip = UpdateTooltip
-	button:SetScript('OnEnter', onEnter)
-	button:SetScript('OnLeave', onLeave)
+	if(options.showStealableBorder or element.showStealableBorder) then
+		local stealable = button:CreateTexture(nil, 'OVERLAY')
+		stealable:SetPoint('TOPLEFT', -3, 3)
+		stealable:SetPoint('BOTTOMRIGHT', 3, -3)
+		stealable:SetTexture([[Interface\TargetingFrame\UI-TargetingFrame-Stealable]])
+		stealable:SetBlendMode('ADD')
+		button.Stealable = stealable
+		button:AddDispelTypeTexture(stealable, {
+			style = Enum.CustomAuraButtonDispelTypeTextureStyle.PreserveAsset, -- since we use a texture
+			showWhenHelpful = true, -- this is required for stealableFilter option
+			showWithoutDispelType = true, -- this is _probably_ required for stealableFilter option
+			stealableFilter = options.stealableBorderFilter or element.stealableBorderFilter or Enum.CustomAuraButtonDispelTypeStealableFilter.Stealable
+		})
+	end
+
+	if(options.showDuration or element.showDuration) then
+		local time = textParent:CreateFontString(nil, 'OVERLAY', 'NumberFontNormal')
+		time:SetPoint('TOPLEFT', 1, 0) -- TBD
+		button.Time = time
+		button:SetDurationText(time, {
+			binding = options.durationBinding or element.durationBinding,
+			textFormatter = options.durationFormatter or element.durationFormatter,
+			textFormat = options.durationFormat or element.durationFormat,
+			textColor = options.durationColors or element.durationColors,
+		})
+	end
+
+	if(options.cancelButton or element.cancelButton) then
+		button:SetCancelAuraButtons(options.cancelButton or element.cancelButton)
+	end
 
 	--[[ Callback: Auras:PostCreateButton(button)
 	Called after a new aura button has been created.
 
-	* self   - the widget holding the aura buttons
-	* button - the newly created aura button (Button)
+	* self    - the element used to represent the aura buttons
+	* button  - the aura button (AuraButton)
+	* options - the aura group/slot options passed through to CreateButton (table)
 	--]]
-	if(element.PostCreateButton) then element:PostCreateButton(button) end
-
-	return button
+	if(element.PostCreateButton) then element:PostCreateButton(button, options) end
 end
 
-local function SetPosition(element, from, to)
-	local width = element.width or element.size or 16
-	local height = element.height or element.size or 16
-	local sizeX = width + (element.spacingX or element.spacing or 0)
-	local sizeY = height + (element.spacingY or element.spacing or 0)
-	local anchor = element.initialAnchor or 'BOTTOMLEFT'
-	local growthX = (element.growthX == 'LEFT' and -1) or 1
-	local growthY = (element.growthY == 'DOWN' and -1) or 1
-	local cols = element.maxCols or math.floor(element:GetWidth() / sizeX + 0.5)
+local elementMixin = {}
+--[[ Auras: auras:AddGroup(filter[, options])
+Defines a group of auras to display on the element.  
+This can be defined multiple times.
 
-	for i = from, to do
-		local button = element[i]
-		if(not button) then break end
+* filter  - aura filter for this group ([AuraFilter](https://warcraft.wiki.gg/wiki/API_type/AuraFilters))
+* options - options for this group (TODO: link to wiki)
 
-		local col = (i - 1) % cols
-		local row = math.floor((i - 1) / cols)
+## Notes
 
-		button:ClearAllPoints()
-		button:SetPoint(anchor, element, anchor, col * sizeX * growthX, row * sizeY * growthY)
+* Many of the options will fall back to element-wide options unless specified.
+* All of the button-specific options can be set in the group options to override the
+element-provided values
+* The groupKey is an arbitrary string used to identify the aura group after creation, and is derived
+from the element's inherited name, suffixed by a growing integer.
+
+## Returns
+
+* groupKey - unique identifier for this specific aura group (string)
+--]]
+function elementMixin:AddGroup(filter, options)
+	argcheck(filter, 2, 'string')
+	argcheck(options, 3, 'table', 'nil')
+
+	-- we use this to pad the options provided (if any) with familiar defaults from
+	-- element attributes like we've been doing for years.
+	if(not options) then
+		options = {}
 	end
-end
 
-local function updateAura(element, unit, data, position)
-	if(not data) then return end
+	-- attributes inherited from the element
+	options.maxFrameCount = options.maxFrameCount or self.maxFrameCount
 
-	local button = element[position]
-	if(not button) then
-		--[[ Override: Auras:CreateButton(position)
-		Used to create an aura button at a given position.
+	-- layout attributes inherited from the element
+	local layout = options.layout or {}
+	layout.elementSpacing = layout.elementSpacing or self.elementSpacing
+	layout.lineSpacing = layout.lineSpacing or self.lineSpacing
+	layout.groupSpacing = layout.groupSpacing or self.groupSpacing
+	layout.groupLineSpacing = layout.groupLineSpacing or self.groupLineSpacing
+	layout.forceNewLine = layout.forceNewLine or self.forceNewLine
+	options.layout = layout
 
-		* self     - the widget holding the aura buttons
-		* position - the position at which the aura button is to be created (number)
+	-- some nice shorthands for stuff that might be shared across groups, with more familiar defaults
+	options.sortMethod = options.sortMethod or self.sortMethod or AuraContainerSortMethod.ExpirationOnly
+	options.sortDirection = options.sortDirection or self.sortDirection or AuraContainerSortDirection.Normal
 
-		## Returns
+	if(not options.initializeFrame) then
+		-- we want to provide a default set of widgets for buttons, and we load it late so we can
+		-- pass group-specific options to it
 
-		* button - the button used to represent the aura (Button)
+		--[[ Override: Auras:CreateButton(options, button)
+		Used to initialize an aura button.
+
+		* self    - the element used to represent the aura buttons
+		* options - options passed through from auras:AddGroup and auras:AddSlot
+		* button  - the aura button (AuraButton)
 		--]]
-		button = (element.CreateButton or CreateButton) (element, position)
-
-		table.insert(element, button)
-		element.createdButtons = element.createdButtons + 1
+		options.initializeFrame = GenerateClosure(options.CreateButton or self.CreateButton or CreateButton, self, options)
 	end
 
-	-- for tooltips
-	button.auraInstanceID = data.auraInstanceID
+	-- keep track of how many groups we've created, for key generation purposes
+	local frame = self.__owner
+	STATE[frame].groupIndex = STATE[frame].groupIndex + 1
 
-	if(button.Cooldown and not element.disableCooldown) then
-		local duration = C_UnitAuras.GetAuraDuration(unit, data.auraInstanceID)
-		if duration then
-			button.Cooldown:SetCooldownFromDurationObject(duration)
-			button.Cooldown:Show()
-		else
-			button.Cooldown:Hide()
-		end
-	end
+	local key = 'Group' .. STATE[frame].groupIndex
+	self:AddAuraGroup(key, filter, options)
 
-	if(button.Overlay) then
-		if(element.showType or (data.isHarmfulAura and element.showDebuffType) or (not data.isHarmfulAura and element.showBuffType)) then
-			local color = C_UnitAuras.GetAuraDispelTypeColor(unit, data.auraInstanceID, element.dispelColorCurve)
-			if color == nil then
-				-- BUG: this shouldn't happen but color can be nil, so default to None color
-				color = element.dispelColorCurve:Evaluate(0)
-			end
-
-			button.Overlay:SetVertexColor(color:GetRGBA())
-			button.Overlay:Show()
-		else
-			button.Overlay:Hide()
-		end
-	end
-
-	if(button.Stealable) then
-		if(element.showStealableBuffs and not UnitCanCooperate('player', unit)) then
-			button.Stealable:SetAlphaFromBoolean(data.isStealable, 1, 0)
-		else
-			button.Stealable:SetAlpha(0)
-		end
-	end
-
-	if(button.Icon) then button.Icon:SetTexture(data.icon) end
-	if(button.Count) then
-		button.Count:SetText(C_UnitAuras.GetAuraApplicationDisplayCount(unit, data.auraInstanceID, element.minCount or 2, element.maxCount or 999))
-	end
-
-	local width = element.width or element.size or 16
-	local height = element.height or element.size or 16
-	button:SetSize(width, height)
-	button:EnableMouse(not element.disableMouse)
-	button:Show()
-
-	--[[ Callback: Auras:PostUpdateButton(unit, button, data, position)
-	Called after the aura button has been updated.
-
-	* self     - the widget holding the aura buttons
-	* button   - the updated aura button (Button)
-	* unit     - the unit for which the update has been triggered (string)
-	* data     - the [AuraData](https://warcraft.wiki.gg/wiki/Struct_AuraData) object (table)
-	* position - the actual position of the aura button (number)
-	--]]
-	if(element.PostUpdateButton) then
-		element:PostUpdateButton(button, unit, data, position)
-	end
+	return key
 end
 
-local function FilterAura(element, unit, data)
-	if((element.onlyShowPlayer and data.isPlayerAura) or not element.onlyShowPlayer) then
-		return true
-	end
-end
+--[[ Auras: auras:AddSlot(filter[, options])
+Defines a slot for a single buff or debuff to create from the element.  
+The slot can be manually positioned if necessary.  
+This can be defined multiple times.
 
--- see AuraUtil.DefaultAuraCompare
-local function SortAuras(a, b)
-	if(a.isPlayerAura ~= b.isPlayerAura) then
-		return a.isPlayerAura
-	end
+* filter  - aura filter for this group ([AuraFilter](https://warcraft.wiki.gg/wiki/API_type/AuraFilters))
+* options - options for this group (TODO: link to wiki)
 
-	return a.auraInstanceID < b.auraInstanceID
-end
+## Notes
 
-local function processData(element, unit, data, filter)
-	if(not data) then return end
+* Many of the options will fall back to element-wide options unless specified.
+* All of the button-specific options can be set in the group options to override the
+element-provided values
+* Slots will be automatically positioned with each other, this can be overridden with ClearAllPoints
+and SetPoint.
+* The slotKey is an arbitrary string used to identify the aura slot after creation, and is derived
+from the element's inherited name, suffixed by a growing integer.
 
-	data.isPlayerAura = not C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, data.auraInstanceID, filter .. '|PLAYER')
-	data.isHarmfulAura = filter:find('HARMFUL') and true -- "isHarmful" is a secret, use a different name
+## Returns
 
-	--[[ Callback: Auras:PostProcessAuraData(unit, data, filter)
-	Called after the aura data has been processed.
+* slotKey - unique identifier for this specific aura slot (string)
+--]]
+function elementMixin:AddSlot(filter, options)
+	argcheck(filter, 2, 'string')
+	argcheck(options, 3, 'table', 'nil')
 
-	* self   - the widget holding the aura buttons
-	* unit   - the unit for which the update has been triggered (string)
-	* data   - [AuraData](https://warcraft.wiki.gg/wiki/Struct_AuraData) object (table)
-	* filter - the aura filter for this aura type
-	## Returns
-
-	* data - the processed aura data (table)
-	--]]
-	if(element.PostProcessAuraData) then
-		data = element:PostProcessAuraData(unit, data, filter)
+	-- we use this to pad the options provided (if any) with familiar defaults from
+	-- element attributes like we've been doing for years.
+	if(not options) then
+		options = {}
 	end
 
-	return data
+	if(not options.initializeFrame) then
+		-- we want to provide a default set of widgets for buttons
+		options.initializeFrame = GenerateClosure(options.CreateButton or self.CreateButton or CreateButton, self, options)
+	end
+
+	-- keep track of how many groups we've created, for key generation purposes
+	local frame = self.__owner
+	STATE[frame].slotIndex = STATE[frame].slotIndex + 1
+
+	local key = 'Slot' .. STATE[frame].slotIndex
+	self:AddAuraSlot(key, filter, options)
+
+	return key
 end
 
-local function UpdateAuras(self, event, unit, updateInfo)
-	if(self.__unit ~= unit) then return end
+--[[ Auras: auras:ForceUpdate()
+Forcefully update all auras within groups and slots on the element.
+--]]
+function elementMixin:ForceUpdate()
+	self:UpdateAllAuras()
+end
 
-	local isFullUpdate = not updateInfo or updateInfo.isFullUpdate
+--[[ Auras: frame:CreateAuras([options])
+Create and return a aura element.
 
-	local auras = self.Auras
-	if(auras) then
-		isFullUpdate = auras.needFullUpdate or isFullUpdate
-		auras.needFullUpdate = false
+* self     - the unit frame on which to create the element
+* options  - extra options to provide to the element
 
-		--[[ Callback: Auras:PreUpdate(unit, isFullUpdate)
-		Called before the element has been updated.
+## Options
 
-		* self         - the widget holding the aura buttons
-		* unit         - the unit for which the update has been triggered (string)
-		* isFullUpdate - indicates whether the element is performing a full update (boolean)
-		--]]
-		if(auras.PreUpdate) then auras:PreUpdate(unit, isFullUpdate) end
+All of these options are provided as a convenience, and can be applied after creation through
+methods on the element.
 
-		local buffsChanged = false
-		local numBuffs = auras.numBuffs or 32
-		local buffFilter = auras.buffFilter or auras.filter or 'HELPFUL'
-		if(type(buffFilter) == 'function') then
-			buffFilter = buffFilter(auras, unit)
+.layout        - Which way to layout groups. Defaults to AnchorUtil.FlowLayoutAxis.Horizontal (number?)
+.layoutLimit   - Max width or height of the element, depending on the layout. Defaults to the parent width or height (number?)
+.initialAnchor - Anchor point for the element. Defaults to 'TOPLEFT' (string?)
+.growthX       - Horizontal growth direction. Defaults to 'RIGHT' (string?)
+.growthY       - Vertical growth direction. Defaults to 'UP' (string?)
+.padding       - Padding around the element. Defaults to 0 (number?)
+.paddingLeft   - Padding on the left side of the element. Takes priority over `padding` (number?)
+.paddingRight  - Padding on the right side of the element. Takes priority over `padding` (number?)
+.paddingTop    - Padding on the top side of the element. Takes priority over `padding` (number?)
+.paddingBottom - Padding on the bottom side of the element. Takes priority over `padding` (number?)
+.policy        - Policy for how auras should be processed. See CustomAuraContainerProcessAuraPolicyDefaultOptions (table?)
+.templates     - Extra templates to use for the aura element (string?)
+
+## Returns
+
+* auras - the element used to represent the aura buttons
+--]]
+local function Create(self, options)
+	-- keep a local state of elements created for each frame
+	if(not STATE[self]) then
+		STATE[self] = {
+			index = 0,
+			elements = {},
+			groupIndex = 0,
+			slotIndex = 0,
+		}
+	end
+
+	local templates = 'CustomAuraContainerTemplate'
+	if(options and options.templates) then
+		templates = templates .. ',' .. options.templates
+	end
+
+	STATE[self].index = STATE[self].index + 1
+	local element = CreateFrame('AuraContainer', '$parentAuras' .. STATE[self].index, self, templates)
+	STATE[self].elements[STATE[self].index] = element
+
+	element.__owner = self
+
+	if(options) then
+		-- element-wide options we'll just set directly from options
+		element:SetFlowLayoutAnchorPoint(options.initialAnchor or 'TOPLEFT')
+
+		if(options.layout) then
+			element:SetFlowLayoutAxis(options.layout)
 		end
 
-		local debuffsChanged = false
-		local numDebuffs = auras.numDebuffs or 40
-		local debuffFilter = auras.debuffFilter or auras.filter or 'HARMFUL'
-		if(type(debuffFilter) == 'function') then
-			debuffFilter = debuffFilter(auras, unit)
-		end
-
-		local numTotal = auras.numTotal or numBuffs + numDebuffs
-
-		if(isFullUpdate) then
-			auras.allBuffs = table.wipe(auras.allBuffs or {})
-			auras.activeBuffs = table.wipe(auras.activeBuffs or {})
-			buffsChanged = true
-
-			local slots = {C_UnitAuras.GetAuraSlots(unit, buffFilter)}
-			for i = 2, #slots do -- #1 return is continuationToken, we don't care about it
-				local data = processData(auras, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), buffFilter)
-				auras.allBuffs[data.auraInstanceID] = data
-
-				--[[ Override: Auras:FilterAura(unit, data, filter)
-				Defines a custom filter that controls if the aura button should be shown.
-
-				* self   - the widget holding the aura buttons
-				* unit   - the unit for which the update has been triggered (string)
-				* data   - [AuraData](https://warcraft.wiki.gg/wiki/Struct_AuraData) object (table)
-				* filter - the aura filter for this aura type
-
-				## Returns
-
-				* show - indicates whether the aura button should be shown (boolean)
-				--]]
-				if((auras.FilterAura or FilterAura) (auras, unit, data, buffFilter)) then
-					auras.activeBuffs[data.auraInstanceID] = true
-				end
-			end
-
-			auras.allDebuffs = table.wipe(auras.allDebuffs or {})
-			auras.activeDebuffs = table.wipe(auras.activeDebuffs or {})
-			debuffsChanged = true
-
-			slots = {C_UnitAuras.GetAuraSlots(unit, debuffFilter)}
-			for i = 2, #slots do
-				local data = processData(auras, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), debuffFilter)
-				auras.allDebuffs[data.auraInstanceID] = data
-
-				if((auras.FilterAura or FilterAura) (auras, unit, data, debuffFilter)) then
-					auras.activeDebuffs[data.auraInstanceID] = true
-				end
-			end
+		if(options.layout == AnchorUtil.FlowLayoutAxis.Vertical) then
+			element:SetFlowLayoutMaximumLineSize(options.layoutLimit or self:GetHeight())
 		else
-			if(updateInfo.addedAuras) then
-				for _, data in next, updateInfo.addedAuras do
-					if(not C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, data.auraInstanceID, buffFilter)) then
-						data = processData(auras, unit, data, buffFilter)
-						auras.allBuffs[data.auraInstanceID] = data
-
-						if((auras.FilterAura or FilterAura) (auras, unit, data, buffFilter)) then
-							auras.activeBuffs[data.auraInstanceID] = true
-							buffsChanged = true
-						end
-					elseif(not C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, data.auraInstanceID, debuffFilter)) then
-						data = processData(auras, unit, data, debuffFilter)
-						auras.allDebuffs[data.auraInstanceID] = data
-
-						if((auras.FilterAura or FilterAura) (auras, unit, data, debuffFilter)) then
-							auras.activeDebuffs[data.auraInstanceID] = true
-							debuffsChanged = true
-						end
-					end
-				end
-			end
-
-			if(updateInfo.updatedAuraInstanceIDs) then
-				for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
-					if(auras.allBuffs[auraInstanceID]) then
-						auras.allBuffs[auraInstanceID] = processData(auras, unit, C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID), buffFilter)
-
-						-- only update if it's actually active
-						if(auras.activeBuffs[auraInstanceID]) then
-							auras.activeBuffs[auraInstanceID] = true
-							buffsChanged = true
-						end
-					elseif(auras.allDebuffs[auraInstanceID]) then
-						auras.allDebuffs[auraInstanceID] = processData(auras, unit, C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID), debuffFilter)
-
-						if(auras.activeDebuffs[auraInstanceID]) then
-							auras.activeDebuffs[auraInstanceID] = true
-							debuffsChanged = true
-						end
-					end
-				end
-			end
-
-			if(updateInfo.removedAuraInstanceIDs) then
-				for _, auraInstanceID in next, updateInfo.removedAuraInstanceIDs do
-					if(auras.allBuffs[auraInstanceID]) then
-						auras.allBuffs[auraInstanceID] = nil
-
-						if(auras.activeBuffs[auraInstanceID]) then
-							auras.activeBuffs[auraInstanceID] = nil
-							buffsChanged = true
-						end
-					elseif(auras.allDebuffs[auraInstanceID]) then
-						auras.allDebuffs[auraInstanceID] = nil
-
-						if(auras.activeDebuffs[auraInstanceID]) then
-							auras.activeDebuffs[auraInstanceID] = nil
-							debuffsChanged = true
-						end
-					end
-				end
-			end
+			element:SetFlowLayoutMaximumLineSize(options.layoutLimit or self:GetWidth())
 		end
 
-		--[[ Callback: Auras:PostUpdateInfo(unit, buffsChanged, debuffsChanged)
-		Called after the aura update info has been updated and filtered, but before sorting.
+		local growthX = (options.growthX == 'LEFT' and -1) or 1
+		local growthY = (options.growthY == 'DOWN' and -1) or 1
+		element:SetFlowLayoutGrowthDirection(growthX, growthY)
 
-		* self           - the widget holding the aura buttons
-		* unit           - the unit for which the update has been triggered (string)
-		* buffsChanged   - indicates whether the buff info has changed (boolean)
-		* debuffsChanged - indicates whether the debuff info has changed (boolean)
-		--]]
-		if(auras.PostUpdateInfo) then
-			auras:PostUpdateInfo(unit, buffsChanged, debuffsChanged)
+		local paddingLeft = options.paddingLeft or options.padding or 0
+		local paddingRight = options.paddingRight or options.padding or 0
+		local paddingTop = options.paddingTop or options.padding or 0
+		local paddingBottom = options.paddingBottom or options.padding or 0
+		element:SetFlowLayoutPadding(paddingLeft, paddingRight, paddingTop, paddingBottom)
+
+		if(options.policy) then
+			-- just expose it easily for layouts in case they want to use it
+			element:SetAuraProcessingPolicy(CustomAuraContainerAuraProcessingPolicy.ProcessAura, options.policy)
 		end
+	end
 
-		if(buffsChanged or debuffsChanged) then
-			local numVisible
+	return Mixin(element, elementMixin)
+end
 
-			if(buffsChanged) then
-				-- instead of removing auras one by one, just wipe the tables entirely
-				-- and repopulate them, multiple table.remove calls are insanely slow
-				auras.sortedBuffs = table.wipe(auras.sortedBuffs or {})
-
-				for auraInstanceID in next, auras.activeBuffs do
-					table.insert(auras.sortedBuffs, auras.allBuffs[auraInstanceID])
-				end
-
-				--[[ Override: Auras:SortBuffs(a, b)
-				Defines a custom sorting algorithm for ordering the auras.
-
-				Defaults to [AuraUtil.DefaultAuraCompare](https://github.com/Gethe/wow-ui-source/search?q=symbol:DefaultAuraCompare).
-				--]]
-				--[[ Override: Auras:SortAuras(a, b)
-				Defines a custom sorting algorithm for ordering the auras.
-
-				Defaults to [AuraUtil.DefaultAuraCompare](https://github.com/Gethe/wow-ui-source/search?q=symbol:DefaultAuraCompare).
-
-				Overridden by the more specific SortBuffs and/or SortDebuffs overrides if they are defined.
-				--]]
-				table.sort(auras.sortedBuffs, auras.SortBuffs or auras.SortAuras or SortAuras)
-
-				numVisible = math.min(numBuffs, numTotal, #auras.sortedBuffs)
-
-				for i = 1, numVisible do
-					updateAura(auras, unit, auras.sortedBuffs[i], i)
-				end
+local function Update(self)
+	if(STATE[self] and STATE[self].elements) then
+		for _, element in next, STATE[self].elements do
+			if element:GetUnit() ~= self.unit then
+				element:SetUnit(self.unit) -- triggers a full update
 			else
-				numVisible = math.min(numBuffs, numTotal, #auras.sortedBuffs)
+				element:ForceUpdate()
 			end
-
-			-- do it before adding the gap because numDebuffs could end up being 0
-			if(debuffsChanged) then
-				auras.sortedDebuffs = table.wipe(auras.sortedDebuffs or {})
-
-				for auraInstanceID in next, auras.activeDebuffs do
-					table.insert(auras.sortedDebuffs, auras.allDebuffs[auraInstanceID])
-				end
-
-				--[[ Override: Auras:SortDebuffs(a, b)
-				Defines a custom sorting algorithm for ordering the auras.
-
-				Defaults to [AuraUtil.DefaultAuraCompare](https://github.com/Gethe/wow-ui-source/search?q=symbol:DefaultAuraCompare).
-				--]]
-				table.sort(auras.sortedDebuffs, auras.SortDebuffs or auras.SortAuras or SortAuras)
-			end
-
-			numDebuffs = math.min(numDebuffs, numTotal - numVisible, #auras.sortedDebuffs)
-
-			if(auras.gap and numVisible > 0 and numDebuffs > 0) then
-				-- adjust the number of visible debuffs if there's an overflow
-				if(numVisible + numDebuffs == numTotal) then
-					numDebuffs = numDebuffs - 1
-				end
-
-				-- double check and skip it if we end up with 0 after the adjustment
-				if(numDebuffs > 0) then
-					numVisible = numVisible + 1
-
-					local button = auras[numVisible]
-					if(not button) then
-						button = (auras.CreateButton or CreateButton) (auras, numVisible)
-						table.insert(auras, button)
-						auras.createdButtons = auras.createdButtons + 1
-					end
-
-					-- prevent the button from displaying anything
-					if(button.Cooldown) then button.Cooldown:Hide() end
-					if(button.Icon) then button.Icon:SetTexture() end
-					if(button.Overlay) then button.Overlay:Hide() end
-					if(button.Stealable) then button.Stealable:Hide() end
-					if(button.Count) then button.Count:SetText() end
-
-					button:EnableMouse(false)
-					button:Show()
-
-					--[[ Callback: Auras:PostUpdateGapButton(unit, gapButton, position)
-					Called after an invisible aura button has been created. Only used by Auras when the `gap` option is enabled.
-
-					* self      - the widget holding the aura buttons
-					* unit      - the unit that has the invisible aura button (string)
-					* gapButton - the invisible aura button (Button)
-					* position  - the position of the invisible aura button (number)
-					--]]
-					if(auras.PostUpdateGapButton) then
-						auras:PostUpdateGapButton(unit, button, numVisible)
-					end
-				end
-			end
-
-			-- any changes to buffs will affect debuffs, so just redraw them even if nothing changed
-			for i = 1, numDebuffs do
-				updateAura(auras, unit, auras.sortedDebuffs[i], numVisible + i)
-			end
-
-			numVisible = numVisible + numDebuffs
-			local visibleChanged = false
-
-			if(numVisible ~= auras.visibleButtons) then
-				auras.visibleButtons = numVisible
-				visibleChanged = auras.reanchorIfVisibleChanged -- more convenient than auras.reanchorIfVisibleChanged and visibleChanged
-			end
-
-			for i = numVisible + 1, #auras do
-				auras[i]:Hide()
-			end
-
-			if(visibleChanged or auras.createdButtons > auras.anchoredButtons) then
-				--[[ Override: Auras:SetPosition(from, to)
-				Used to (re-)anchor the aura buttons.
-				Called when new aura buttons have been created or the number of visible buttons has changed if the
-				`.reanchorIfVisibleChanged` option is enabled.
-
-				* self - the widget that holds the aura buttons
-				* from - the offset of the first aura button to be (re-)anchored (number)
-				* to   - the offset of the last aura button to be (re-)anchored (number)
-				--]]
-				if(visibleChanged) then
-					-- this is useful for when people might want centred auras, like nameplates
-					(auras.SetPosition or SetPosition) (auras, 1, numVisible)
-				else
-					(auras.SetPosition or SetPosition) (auras, auras.anchoredButtons + 1, auras.createdButtons)
-					auras.anchoredButtons = auras.createdButtons
-				end
-			end
-
-			--[[ Callback: Auras:PostUpdate(unit)
-			Called after the element has been updated.
-
-			* self - the widget holding the aura buttons
-			* unit - the unit for which the update has been triggered (string)
-			--]]
-			if(auras.PostUpdate) then auras:PostUpdate(unit) end
 		end
 	end
-
-	local buffs = self.Buffs
-	if(buffs) then
-		isFullUpdate = buffs.needFullUpdate or isFullUpdate
-		buffs.needFullUpdate = false
-
-		if(buffs.PreUpdate) then buffs:PreUpdate(unit, isFullUpdate) end
-
-		local buffsChanged = false
-		local numBuffs = buffs.num or 32
-		local buffFilter = buffs.filter or 'HELPFUL'
-		if(type(buffFilter) == 'function') then
-			buffFilter = buffFilter(buffs, unit)
-		end
-
-		if(isFullUpdate) then
-			buffs.all = table.wipe(buffs.all or {})
-			buffs.active = table.wipe(buffs.active or {})
-			buffsChanged = true
-
-			local slots = {C_UnitAuras.GetAuraSlots(unit, buffFilter)}
-			for i = 2, #slots do
-				local data = processData(buffs, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), buffFilter)
-				buffs.all[data.auraInstanceID] = data
-
-				if((buffs.FilterAura or FilterAura) (buffs, unit, data, buffFilter)) then
-					buffs.active[data.auraInstanceID] = true
-				end
-			end
-		else
-			if(updateInfo.addedAuras) then
-				for _, data in next, updateInfo.addedAuras do
-					if(not C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, data.auraInstanceID, buffFilter)) then
-						buffs.all[data.auraInstanceID] = processData(buffs, unit, data, buffFilter)
-
-						if((buffs.FilterAura or FilterAura) (buffs, unit, data, buffFilter)) then
-							buffs.active[data.auraInstanceID] = true
-							buffsChanged = true
-						end
-					end
-				end
-			end
-
-			if(updateInfo.updatedAuraInstanceIDs) then
-				for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
-					if(buffs.all[auraInstanceID]) then
-						buffs.all[auraInstanceID] = processData(buffs, unit, C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID), buffFilter)
-
-						if(buffs.active[auraInstanceID]) then
-							buffs.active[auraInstanceID] = true
-							buffsChanged = true
-						end
-					end
-				end
-			end
-
-			if(updateInfo.removedAuraInstanceIDs) then
-				for _, auraInstanceID in next, updateInfo.removedAuraInstanceIDs do
-					if(buffs.all[auraInstanceID]) then
-						buffs.all[auraInstanceID] = nil
-
-						if(buffs.active[auraInstanceID]) then
-							buffs.active[auraInstanceID] = nil
-							buffsChanged = true
-						end
-					end
-				end
-			end
-		end
-
-		if(buffs.PostUpdateInfo) then
-			buffs:PostUpdateInfo(unit, buffsChanged)
-		end
-
-		if(buffsChanged) then
-			buffs.sorted = table.wipe(buffs.sorted or {})
-
-			for auraInstanceID in next, buffs.active do
-				table.insert(buffs.sorted, buffs.all[auraInstanceID])
-			end
-
-			table.sort(buffs.sorted, buffs.SortBuffs or buffs.SortAuras or SortAuras)
-
-			local numVisible = math.min(numBuffs, #buffs.sorted)
-
-			for i = 1, numVisible do
-				updateAura(buffs, unit, buffs.sorted[i], i)
-			end
-
-			local visibleChanged = false
-
-			if(numVisible ~= buffs.visibleButtons) then
-				buffs.visibleButtons = numVisible
-				visibleChanged = buffs.reanchorIfVisibleChanged
-			end
-
-			for i = numVisible + 1, #buffs do
-				buffs[i]:Hide()
-			end
-
-			if(visibleChanged or buffs.createdButtons > buffs.anchoredButtons) then
-				if(visibleChanged) then
-					(buffs.SetPosition or SetPosition) (buffs, 1, numVisible)
-				else
-					(buffs.SetPosition or SetPosition) (buffs, buffs.anchoredButtons + 1, buffs.createdButtons)
-					buffs.anchoredButtons = buffs.createdButtons
-				end
-			end
-
-			if(buffs.PostUpdate) then buffs:PostUpdate(unit) end
-		end
-	end
-
-	local debuffs = self.Debuffs
-	if(debuffs) then
-		isFullUpdate = debuffs.needFullUpdate or isFullUpdate
-		debuffs.needFullUpdate = false
-
-		if(debuffs.PreUpdate) then debuffs:PreUpdate(unit, isFullUpdate) end
-
-		local debuffsChanged = false
-		local numDebuffs = debuffs.num or 40
-		local debuffFilter = debuffs.filter or 'HARMFUL'
-		if(type(debuffFilter) == 'function') then
-			debuffFilter = debuffFilter(debuffs, unit)
-		end
-
-		if(isFullUpdate) then
-			debuffs.all = table.wipe(debuffs.all or {})
-			debuffs.active = table.wipe(debuffs.active or {})
-			debuffsChanged = true
-
-			local slots = {C_UnitAuras.GetAuraSlots(unit, debuffFilter)}
-			for i = 2, #slots do
-				local data = processData(debuffs, unit, C_UnitAuras.GetAuraDataBySlot(unit, slots[i]), debuffFilter)
-				debuffs.all[data.auraInstanceID] = data
-
-				if((debuffs.FilterAura or FilterAura) (debuffs, unit, data, debuffFilter)) then
-					debuffs.active[data.auraInstanceID] = true
-				end
-			end
-		else
-			if(updateInfo.addedAuras) then
-				for _, data in next, updateInfo.addedAuras do
-					if(not C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, data.auraInstanceID, debuffFilter)) then
-						debuffs.all[data.auraInstanceID] = processData(debuffs, unit, data, debuffFilter)
-
-						if((debuffs.FilterAura or FilterAura) (debuffs, unit, data, debuffFilter)) then
-							debuffs.active[data.auraInstanceID] = true
-							debuffsChanged = true
-						end
-					end
-				end
-			end
-
-			if(updateInfo.updatedAuraInstanceIDs) then
-				for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
-					if(debuffs.all[auraInstanceID]) then
-						debuffs.all[auraInstanceID] = processData(debuffs, unit, C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID), debuffFilter)
-
-						if(debuffs.active[auraInstanceID]) then
-							debuffs.active[auraInstanceID] = true
-							debuffsChanged = true
-						end
-					end
-				end
-			end
-
-			if(updateInfo.removedAuraInstanceIDs) then
-				for _, auraInstanceID in next, updateInfo.removedAuraInstanceIDs do
-					if(debuffs.all[auraInstanceID]) then
-						debuffs.all[auraInstanceID] = nil
-
-						if(debuffs.active[auraInstanceID]) then
-							debuffs.active[auraInstanceID] = nil
-							debuffsChanged = true
-						end
-					end
-				end
-			end
-		end
-
-		if(debuffs.PostUpdateInfo) then
-			debuffs:PostUpdateInfo(unit, debuffsChanged)
-		end
-
-		if(debuffsChanged) then
-			debuffs.sorted = table.wipe(debuffs.sorted or {})
-
-			for auraInstanceID in next, debuffs.active do
-				table.insert(debuffs.sorted, debuffs.all[auraInstanceID])
-			end
-
-			table.sort(debuffs.sorted, debuffs.SortDebuffs or debuffs.SortAuras or SortAuras)
-
-			local numVisible = math.min(numDebuffs, #debuffs.sorted)
-
-			for i = 1, numVisible do
-				updateAura(debuffs, unit, debuffs.sorted[i], i)
-			end
-
-			local visibleChanged = false
-
-			if(numVisible ~= debuffs.visibleButtons) then
-				debuffs.visibleButtons = numVisible
-				visibleChanged = debuffs.reanchorIfVisibleChanged
-			end
-
-			for i = numVisible + 1, #debuffs do
-				debuffs[i]:Hide()
-			end
-
-			if(visibleChanged or debuffs.createdButtons > debuffs.anchoredButtons) then
-				if(visibleChanged) then
-					(debuffs.SetPosition or SetPosition) (debuffs, 1, numVisible)
-				else
-					(debuffs.SetPosition or SetPosition) (debuffs, debuffs.anchoredButtons + 1, debuffs.createdButtons)
-					debuffs.anchoredButtons = debuffs.createdButtons
-				end
-			end
-
-			if(debuffs.PostUpdate) then debuffs:PostUpdate(unit) end
-		end
-	end
-end
-
-local function Update(self, event, unit, updateInfo)
-	if(self.__unit ~= unit) then return end
-
-	UpdateAuras(self, event, unit, updateInfo)
-
-	-- Assume no event means someone wants to re-anchor things. This is usually
-	-- done by UpdateAllElements and :ForceUpdate.
-	if(event == 'ForceUpdate' or not event) then
-		local auras = self.Auras
-		if(auras) then
-			(auras.SetPosition or SetPosition) (auras, 1, auras.createdButtons)
-		end
-
-		local buffs = self.Buffs
-		if(buffs) then
-			(buffs.SetPosition or SetPosition) (buffs, 1, buffs.createdButtons)
-		end
-
-		local debuffs = self.Debuffs
-		if(debuffs) then
-			(debuffs.SetPosition or SetPosition) (debuffs, 1, debuffs.createdButtons)
-		end
-	end
-end
-
-local function ForceUpdate(element)
-	return Update(element.__owner, 'ForceUpdate', element.__owner.__unit)
 end
 
 local function Enable(self)
-	if(self.Auras or self.Buffs or self.Debuffs) then
-		self:RegisterEvent('UNIT_AURA', UpdateAuras)
-
-		local auras = self.Auras
-		if(auras) then
-			auras.__owner = self
-			-- check if there's any anchoring restrictions
-			auras.__restricted = not pcall(self.GetCenter, self)
-			auras.ForceUpdate = ForceUpdate
-
-			auras.createdButtons = auras.createdButtons or 0
-			auras.anchoredButtons = 0
-			auras.visibleButtons = 0
-			auras.tooltipAnchor = auras.tooltipAnchor or 'ANCHOR_BOTTOMRIGHT'
-			auras.needFullUpdate = true
-
-			if(not auras.dispelColorCurve) then
-				auras.dispelColorCurve = C_CurveUtil.CreateColorCurve()
-				auras.dispelColorCurve:SetType(Enum.LuaCurveType.Step)
-				for _, dispelIndex in next, oUF.Enum.DispelType do
-					if(self.colors.dispel[dispelIndex]) then
-						auras.dispelColorCurve:AddPoint(dispelIndex, self.colors.dispel[dispelIndex])
-					end
-				end
-			end
-
-			auras:Show()
-		end
-
-		local buffs = self.Buffs
-		if(buffs) then
-			buffs.__owner = self
-			-- check if there's any anchoring restrictions
-			buffs.__restricted = not pcall(self.GetCenter, self)
-			buffs.ForceUpdate = ForceUpdate
-
-			buffs.createdButtons = buffs.createdButtons or 0
-			buffs.anchoredButtons = 0
-			buffs.visibleButtons = 0
-			buffs.tooltipAnchor = buffs.tooltipAnchor or 'ANCHOR_BOTTOMRIGHT'
-			buffs.needFullUpdate = true
-
-			if(not buffs.dispelColorCurve) then
-				buffs.dispelColorCurve = C_CurveUtil.CreateColorCurve()
-				buffs.dispelColorCurve:SetType(Enum.LuaCurveType.Step)
-				for _, dispelIndex in next, oUF.Enum.DispelType do
-					if(self.colors.dispel[dispelIndex]) then
-						buffs.dispelColorCurve:AddPoint(dispelIndex, self.colors.dispel[dispelIndex])
-					end
-				end
-			end
-
-			buffs:Show()
-		end
-
-		local debuffs = self.Debuffs
-		if(debuffs) then
-			debuffs.__owner = self
-			-- check if there's any anchoring restrictions
-			debuffs.__restricted = not pcall(self.GetCenter, self)
-			debuffs.ForceUpdate = ForceUpdate
-
-			debuffs.createdButtons = debuffs.createdButtons or 0
-			debuffs.anchoredButtons = 0
-			debuffs.visibleButtons = 0
-			debuffs.tooltipAnchor = debuffs.tooltipAnchor or 'ANCHOR_BOTTOMRIGHT'
-			debuffs.needFullUpdate = true
-
-			if(not debuffs.dispelColorCurve) then
-				debuffs.dispelColorCurve = C_CurveUtil.CreateColorCurve()
-				debuffs.dispelColorCurve:SetType(Enum.LuaCurveType.Step)
-				for _, dispelIndex in next, oUF.Enum.DispelType do
-					if(self.colors.dispel[dispelIndex]) then
-						debuffs.dispelColorCurve:AddPoint(dispelIndex, self.colors.dispel[dispelIndex])
-					end
-				end
-			end
-
-			debuffs:Show()
+	if(STATE[self] and STATE[self].elements) then
+		for _, element in next, STATE[self].elements do
+			element:SetEnabled(true) -- triggers a full update
 		end
 
 		return true
@@ -926,13 +434,11 @@ local function Enable(self)
 end
 
 local function Disable(self)
-	if(self.Auras or self.Buffs or self.Debuffs) then
-		self:UnregisterEvent('UNIT_AURA', UpdateAuras)
-
-		if(self.Auras) then self.Auras:Hide() end
-		if(self.Buffs) then self.Buffs:Hide() end
-		if(self.Debuffs) then self.Debuffs:Hide() end
+	if(STATE[self] and STATE[self].elements) then
+		for _, element in next, STATE[self].elements do
+			element:SetEnabled(false)
+		end
 	end
 end
 
-oUF:AddElement('Auras', Update, Enable, Disable)
+oUF:AddMetaElement('Auras', Create, Update, Enable, Disable)

--- a/elements/auras.lua
+++ b/elements/auras.lua
@@ -414,8 +414,8 @@ end
 local function Update(self)
 	if(STATE[self] and STATE[self].elements) then
 		for _, element in next, STATE[self].elements do
-			if element:GetUnit() ~= self.unit then
-				element:SetUnit(self.unit) -- triggers a full update
+			if element:GetUnit() ~= self.__unit then
+				element:SetUnit(self.__unit) -- triggers a full update
 			else
 				element:ForceUpdate()
 			end

--- a/enums.lua
+++ b/enums.lua
@@ -1,18 +1,7 @@
 local _, ns = ...
 local oUF = ns.oUF
 
--- we have to do this until Blizzard decides to add an Enum
 oUF.Enum = {}
-oUF.Enum.DispelType = {
-	-- https://wago.tools/db2/SpellDispelType
-	None = 0,
-	Magic = 1,
-	Curse = 2,
-	Disease = 3,
-	Poison = 4,
-	Enrage = 9,
-	Bleed = 11,
-}
 
 oUF.Enum.SelectionType = {
 	-- https://warcraft.wiki.gg/wiki/API_UnitSelectionType

--- a/ouf.lua
+++ b/ouf.lua
@@ -1115,6 +1115,32 @@ function oUF:AddElement(name, update, enable, disable)
 	}
 end
 
+--[[ oUF:AddMetaElement(name, create, update, enable, disable)
+Used to register a meta element with oUF.
+
+* self    - the global oUF object
+* name    - unique name of the element (string)
+* create  - used to create the element. Will be registered as a meta function (function)
+* update  - used to update the element (function)
+* enable  - used to enable the element for a given unit frame and unit (function)
+* disable - used to disable the element for a given unit frame (function)
+--]]
+function oUF:AddMetaElement(name, create, update, enable, disable)
+	argcheck(name, 2, 'string')
+	argcheck(create, 3, 'function')
+	argcheck(update, 4, 'function', 'nil')
+	argcheck(enable, 5, 'function')
+	argcheck(disable, 6, 'function')
+
+	if(elements[name]) then return nierror(string.format('Element [%s] is already registered.', name)) end
+	elements[name] = {
+		update = update,
+		enable = enable,
+		disable = disable,
+	}
+	self:RegisterMetaFunction('Create' .. name, create)
+end
+
 oUF.version = _VERSION
 --[[ oUF.objects
 Array containing all unit frames created by `oUF:Spawn`.


### PR DESCRIPTION
In broad terms, the way we've been doing auras for years in oUF is now over, we hand all of the logic over to Blizzard and we just wrap their new shiny way of dealing with auras in a wrapper that makes it a bit more familiar to users of oUF, and deal with some of the necessary manual handling of unit updates and such so the layouts don't have to (very much on-brand for oUF).

Don't look at this PR as a diff, pretend like the original auras implementation is now fully gone and think of the new one as a new implementation, because that's what is really is - they share nothing alike but some option names and the button template (to some degree). I.e. just look at the file directly: https://github.com/oUF-wow/oUF/blob/aurapocalypse/elements/auras.lua

The element is now invoked similar to tags, as layouts request aura containers through a new meta method on each unit frame, with some additional methods attached to make it slightly easier to work with (although they're not necessary to use if you don't want to - i.e. if you replaced `CreateButton` before then you don't need to use the extra methods at all).

