### PR TITLE
raidroleindicator: Account for secret party assignments

### DIFF
--- a/elements/raidroleindicator.lua
+++ b/elements/raidroleindicator.lua
@@ -44,11 +44,13 @@ local function Update(self, event)
 
 	local role, shouldShow
 	if(UnitInRaid(unit) ~= nil and not UnitHasVehicleUI(unit)) then
-		if(GetPartyAssignment('MAINTANK', unit)) then
+		local isMainTank = GetPartyAssignment('MAINTANK', unit)
+		local isMainAssist = GetPartyAssignment('MAINASSIST', unit)
+		if(not issecretvalue(isMainTank) and isMainTank) then
 			role = 'MAINTANK'
 			shouldShow = true
 			element:SetAtlas('RaidFrame-Icon-MainTank', element.useAtlasSize)
-		elseif(GetPartyAssignment('MAINASSIST', unit)) then
+		elseif(not issecretvalue(isMainAssist) and isMainAssist) then
 			role = 'MAINASSIST'
 			shouldShow = true
 			element:SetAtlas('RaidFrame-Icon-MainAssist', element.useAtlasSize)


### PR DESCRIPTION
## Problem

`GetPartyAssignment` can return a secret boolean in 12.1. `raidroleindicator` boolean-tests both return values directly, which throws:

```
elements/raidroleindicator.lua:47: attempt to perform boolean test on a secret boolean value
```

Because both calls are inside `Update`, which runs per raid unit on every update, this doesn't throw once — it throws continuously for as long as you're in a raid. I captured **5,476 occurrences in a single raid session**, enough to trip the client's "too many errors" cutoff and drown out every other error in the log.

## Fix

Assign each result to a local and gate on `issecretvalue` before testing, matching the existing handling in `pvpindicator.lua`:

```lua
local isPvP = UnitIsPVP(unit)
if(factionGroup ~= 'Neutral' and not issecretvalue(isPvP) and isPvP) then
```

One behavioural note: `MAINASSIST` is now fetched up front rather than only when the `MAINTANK` branch fails. This mirrors how `pvpindicator` already resolves `honorRewardInfo` unconditionally. Happy to nest the second lookup instead if you'd prefer to avoid the extra call.

## Testing status

Being straight about what has and hasn't been confirmed:

- [x] Error reproduced on a live 12.1 retail client — 5,476 occurrences in one raid session, captured via BugGrabber (via SpartanUI's embedded copy of this element).
- [ ] **Not yet runtime-verified.** The patch is applied to my local install but I haven't been back into a raid since. I'll report back once I have; happy for you to hold the PR until then.

The change is small and follows the established pattern, but I'd rather flag the gap than imply testing I haven't done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)