### PR TITLE
raidroleindicator: Account for secret assigments

### DIFF
--- a/elements/raidroleindicator.lua
+++ b/elements/raidroleindicator.lua
@@ -29,6 +29,8 @@ This element updates by changing the texture.
 local _, ns = ...
 local oUF = ns.oUF
 
+local STATE = {}
+
 local function Update(self, event)
 	local element = self.RaidRoleIndicator
 	local unit = self.__unit
@@ -44,11 +46,25 @@ local function Update(self, event)
 
 	local role, shouldShow
 	if(UnitInRaid(unit) ~= nil and not UnitHasVehicleUI(unit)) then
-		if(GetPartyAssignment('MAINTANK', unit)) then
+		local isMainTank = GetPartyAssignment('MAINTANK', unit)
+		if(issecretvalue(isMainTank)) then
+			isMainTank = STATE[element].isMainTank
+		else
+			STATE[element].isMainTank = isMainTank
+		end
+
+		local isMainAssist = GetPartyAssignment('MAINASSIST', unit)
+		if(issecretvalue(isMainAssist)) then
+			isMainAssist = STATE[element].isMainAssist
+		else
+			STATE[element].isMainAssist = isMainAssist
+		end
+
+		if(isMainTank) then
 			role = 'MAINTANK'
 			shouldShow = true
 			element:SetAtlas('RaidFrame-Icon-MainTank', element.useAtlasSize)
-		elseif(GetPartyAssignment('MAINASSIST', unit)) then
+		elseif(isMainAssist) then
 			role = 'MAINASSIST'
 			shouldShow = true
 			element:SetAtlas('RaidFrame-Icon-MainAssist', element.useAtlasSize)
@@ -89,7 +105,10 @@ local function Enable(self)
 		element.__owner = self
 		element.ForceUpdate = ForceUpdate
 
+		STATE[element] = {}
+
 		self:RegisterEvent('GROUP_ROSTER_UPDATE', Path, true)
+		self:RegisterEvent('PLAYER_REGEN_ENABLED', Path, true)
 
 		return true
 	end
@@ -101,6 +120,7 @@ local function Disable(self)
 		element:Hide()
 
 		self:UnregisterEvent('GROUP_ROSTER_UPDATE', Path)
+		self:UnregisterEvent('PLAYER_REGEN_ENABLED', Path)
 	end
 end
 

--- a/elements/raidroleindicator.lua
+++ b/elements/raidroleindicator.lua
@@ -44,6 +44,10 @@ local function Update(self, event)
 		element:PreUpdate()
 	end
 
+	if(event == 'OnShow') then
+		STATE[element] = {}
+	end
+
 	local role, shouldShow
 	if(UnitInRaid(unit) ~= nil and not UnitHasVehicleUI(unit)) then
 		local isMainTank = GetPartyAssignment('MAINTANK', unit)


### PR DESCRIPTION
While #880 accounts for secret assignments it would hide the indicators outright if the assignments were secret, removing existing information from the player. This PR will use a cached state while secrets are in effect, and do an update again when secrecy is (presumably) gone after combat ends.

Closes #880